### PR TITLE
Internationalize GUI and fix Visio conversion layout

### DIFF
--- a/md2visio.GUI/Forms/MainForm.cs
+++ b/md2visio.GUI/Forms/MainForm.cs
@@ -1,4 +1,5 @@
 using md2visio.GUI.Services;
+using md2visio.GUI.Localization;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -28,6 +29,8 @@ namespace md2visio.GUI.Forms
         private Button _startConversionButton = null!;
         private Button _openOutputButton = null!;
         private Button _clearLogButton = null!;
+        private ComboBox _languageComboBox = null!;
+        private bool _changingLanguage;
 
 
         private string? _selectedFilePath;
@@ -46,7 +49,7 @@ namespace md2visio.GUI.Forms
         private void InitializeComponent()
         {
             // 窗口设置
-            Text = "md2visio - Mermaid 转 Visio 工具";
+            Text = UiStrings.Get("AppTitle");
             Size = new Size(1250, 850);
             StartPosition = FormStartPosition.CenterScreen;
             MinimumSize = new Size(600, 500);
@@ -83,25 +86,57 @@ namespace md2visio.GUI.Forms
 
         private void CreateTitleArea(TableLayoutPanel parent, int row)
         {
+            var container = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 3,
+                RowCount = 1
+            };
+            container.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+            container.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            container.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+
             var titleLabel = new Label
             {
-                Text = "📄 md2visio - Mermaid 转 Visio 工具",
-                Font = new Font("Microsoft YaHei UI", 12, FontStyle.Bold),
+                Text = UiStrings.Get("HeaderTitle"),
+                Font = UiFont(12, FontStyle.Bold),
                 ForeColor = Color.DarkBlue,
                 Dock = DockStyle.Fill,
                 TextAlign = ContentAlignment.MiddleLeft
             };
 
-            parent.Controls.Add(titleLabel, 0, row);
+            var languageLabel = new Label
+            {
+                Text = UiStrings.Get("Language"),
+                AutoSize = true,
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleRight,
+                Margin = new Padding(8, 0, 5, 0)
+            };
+
+            _languageComboBox = new ComboBox
+            {
+                Dock = DockStyle.Fill,
+                DropDownStyle = ComboBoxStyle.DropDownList
+            };
+            _languageComboBox.Items.Add(new LanguageChoice("en", UiStrings.Get("English")));
+            _languageComboBox.Items.Add(new LanguageChoice("zh-CN", UiStrings.Get("Chinese")));
+            _languageComboBox.SelectedIndex = CultureSettings.CurrentCultureName == "zh-CN" ? 1 : 0;
+            _languageComboBox.SelectedIndexChanged += OnLanguageChanged;
+
+            container.Controls.Add(titleLabel, 0, 0);
+            container.Controls.Add(languageLabel, 1, 0);
+            container.Controls.Add(_languageComboBox, 2, 0);
+            parent.Controls.Add(container, 0, row);
         }
 
         private void CreateFileSelectionArea(TableLayoutPanel parent, int row)
         {
             var groupBox = new GroupBox
             {
-                Text = "📁 输入文件",
+                Text = UiStrings.Get("InputFile"),
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold)
+                Font = UiFont(9, FontStyle.Bold)
             };
 
             var container = new TableLayoutPanel
@@ -127,29 +162,29 @@ namespace md2visio.GUI.Forms
 
             _dragDropLabel = new Label
             {
-                Text = "将 .md 文件拖拽到此处或点击浏览选择",
+                Text = UiStrings.Get("DropHint"),
                 TextAlign = ContentAlignment.MiddleCenter,
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 10)
+                Font = UiFont(10)
             };
             _dragDropPanel.Controls.Add(_dragDropLabel);
 
             // 浏览按钮
             _browseFileButton = new Button
             {
-                Text = "浏览文件...",
+                Text = UiStrings.Get("BrowseFiles"),
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 9),
+                Font = UiFont(9),
                 Margin = new Padding(10, 0, 0, 0)
             };
 
             // 选中文件显示
             _selectedFileLabel = new Label
             {
-                Text = "未选择文件",
+                Text = UiStrings.Get("NoFileSelected"),
                 Dock = DockStyle.Fill,
                 ForeColor = Color.Gray,
-                Font = new Font("Microsoft YaHei UI", 8)
+                Font = UiFont(8)
             };
 
             container.Controls.Add(_dragDropPanel, 0, 0);
@@ -165,9 +200,9 @@ namespace md2visio.GUI.Forms
         {
             var groupBox = new GroupBox
             {
-                Text = "📂 输出设置",
+                Text = UiStrings.Get("OutputSettings"),
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold)
+                Font = UiFont(9, FontStyle.Bold)
             };
 
             var container = new TableLayoutPanel
@@ -184,14 +219,14 @@ namespace md2visio.GUI.Forms
             container.RowStyles.Add(new RowStyle(SizeType.Absolute, 45));
 
             // 输出目录
-            var outputDirLabel = new Label { Text = "输出目录:", TextAlign = ContentAlignment.MiddleRight, Dock = DockStyle.Fill, Font = new Font("Microsoft YaHei UI", 9) };
-            _outputDirTextBox = new TextBox { Text = Environment.GetFolderPath(Environment.SpecialFolder.Desktop), Dock = DockStyle.Fill, Font = new Font("Microsoft YaHei UI", 9) };
-            _selectDirButton = new Button { Text = "选择目录...", Dock = DockStyle.Fill, Margin = new Padding(5, 0, 0, 0), Font = new Font("Microsoft YaHei UI", 9) };
+            var outputDirLabel = new Label { Text = UiStrings.Get("OutputDirectory"), TextAlign = ContentAlignment.MiddleRight, Dock = DockStyle.Fill, Font = SystemFonts.MessageBoxFont };
+            _outputDirTextBox = new TextBox { Text = Environment.GetFolderPath(Environment.SpecialFolder.Desktop), Dock = DockStyle.Fill, Font = UiFont(9) };
+            _selectDirButton = new Button { Text = UiStrings.Get("SelectDirectory"), Dock = DockStyle.Fill, Margin = new Padding(5, 0, 0, 0), Font = SystemFonts.MessageBoxFont };
 
             // 文件名
-            var fileNameLabel = new Label { Text = "文件名:", TextAlign = ContentAlignment.MiddleRight, Dock = DockStyle.Fill, Font = new Font("Microsoft YaHei UI", 9) };
-            _fileNameTextBox = new TextBox { Text = "output", Dock = DockStyle.Fill, Font = new Font("Microsoft YaHei UI", 9) };
-            var extensionLabel = new Label { Text = ".vsdx", TextAlign = ContentAlignment.MiddleLeft, Dock = DockStyle.Fill, Font = new Font("Microsoft YaHei UI", 9) };
+            var fileNameLabel = new Label { Text = UiStrings.Get("FileName"), TextAlign = ContentAlignment.MiddleRight, Dock = DockStyle.Fill, Font = SystemFonts.MessageBoxFont };
+            _fileNameTextBox = new TextBox { Text = "output", Dock = DockStyle.Fill, Font = UiFont(9) };
+            var extensionLabel = new Label { Text = ".vsdx", TextAlign = ContentAlignment.MiddleLeft, Dock = DockStyle.Fill, Font = UiFont(9) };
 
             container.Controls.Add(outputDirLabel, 0, 0);
             container.Controls.Add(_outputDirTextBox, 1, 0);
@@ -208,9 +243,9 @@ namespace md2visio.GUI.Forms
         {
             var groupBox = new GroupBox
             {
-                Text = "⚙️ 转换选项",
+                Text = UiStrings.Get("ConversionOptions"),
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold)
+                Font = UiFont(9, FontStyle.Bold)
             };
 
             var container = new FlowLayoutPanel
@@ -223,17 +258,17 @@ namespace md2visio.GUI.Forms
 
             _showVisioCheckBox = new CheckBox
             {
-                Text = "显示 Visio 窗口",
+                Text = UiStrings.Get("ShowVisio"),
                 AutoSize = true,
-                Font = new Font("Microsoft YaHei UI", 9),
+                Font = UiFont(9),
                 Margin = new Padding(0, 0, 30, 0)
             };
 
             _silentOverwriteCheckBox = new CheckBox
             {
-                Text = "静默覆盖文件",
+                Text = UiStrings.Get("SilentOverwrite"),
                 AutoSize = true,
-                Font = new Font("Microsoft YaHei UI", 9),
+                Font = UiFont(9),
                 Checked = true
             };
 
@@ -248,9 +283,9 @@ namespace md2visio.GUI.Forms
         {
             var groupBox = new GroupBox
             {
-                Text = "📊 支持的图表类型",
+                Text = UiStrings.Get("SupportedTypes"),
                 Dock = DockStyle.Top,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold),
+                Font = UiFont(9, FontStyle.Bold),
                 AutoSize = true,
                 AutoSizeMode = AutoSizeMode.GrowAndShrink
             };
@@ -268,13 +303,13 @@ namespace md2visio.GUI.Forms
             // 创建单个类型标签
             var supportedTypes = new[]
             {
-                ("✅ 流程图", "graph/flowchart"),
-                ("✅ 饼图", "pie"),
-                ("✅ 用户旅程图", "journey"),
-                ("✅ 数据包图", "packet"),
-                ("✅ XY图表", "xychart"),
-                ("✅ 时序图", "sequence"),
-                ("✅ 实体关系图", "er")
+                (UiStrings.Get("Flowchart"), "graph/flowchart"),
+                (UiStrings.Get("PieChart"), "pie"),
+                (UiStrings.Get("UserJourney"), "journey"),
+                (UiStrings.Get("PacketDiagram"), "packet"),
+                (UiStrings.Get("XYChart"), "xychart"),
+                (UiStrings.Get("SequenceDiagram"), "sequence"),
+                (UiStrings.Get("EntityRelationshipDiagram"), "er")
             };
 
             foreach (var (icon, name) in supportedTypes)
@@ -283,7 +318,7 @@ namespace md2visio.GUI.Forms
                 {
                     Text = $"{icon} {name}",
                     AutoSize = true,
-                    Font = new Font("Microsoft YaHei UI", 9),
+                    Font = UiFont(9),
                     ForeColor = icon.StartsWith("✅") ? Color.DarkGreen : Color.Red,
                     Margin = new Padding(0, 5, 15, 5)
                 };
@@ -309,9 +344,9 @@ namespace md2visio.GUI.Forms
         {
             var groupBox = new GroupBox
             {
-                Text = "📝 转换日志",
+                Text = UiStrings.Get("ConversionLog"),
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold)
+                Font = UiFont(9, FontStyle.Bold)
             };
 
             var container = new TableLayoutPanel
@@ -335,9 +370,9 @@ namespace md2visio.GUI.Forms
 
             _clearLogButton = new Button
             {
-                Text = "清空日志",
+                Text = UiStrings.Get("ClearLog"),
                 Dock = DockStyle.Fill,
-                Font = new Font("Microsoft YaHei UI", 9),
+                Font = UiFont(9),
                 Margin = new Padding(5, 5, 0, 5),
                 MinimumSize = new Size(85, 30)
             };
@@ -369,26 +404,26 @@ namespace md2visio.GUI.Forms
             // 按钮
             _startConversionButton = new Button
             {
-                Text = "🚀 开始转换",
+                Text = UiStrings.Get("StartConversion"),
                 Dock = DockStyle.Fill,
                 BackColor = Color.LightGreen,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold),
+                Font = UiFont(9, FontStyle.Bold),
                 Margin = new Padding(0, 0, 5, 0)
             };
 
             var checkVisioButton = new Button
             {
-                Text = "🔍 检查Visio",
+                Text = UiStrings.Get("CheckVisio"),
                 Dock = DockStyle.Fill,
                 BackColor = Color.LightBlue,
-                Font = new Font("Microsoft YaHei UI", 9, FontStyle.Bold),
+                Font = UiFont(9, FontStyle.Bold),
                 Margin = new Padding(0, 0, 5, 0)
             };
             checkVisioButton.Click += OnCheckVisioClick;
 
             _openOutputButton = new Button
             {
-                Text = "📁 打开输出目录",
+                Text = UiStrings.Get("OpenOutput"),
                 Dock = DockStyle.Fill,
                 Enabled = false,
                 Margin = new Padding(0, 0, 5, 0)
@@ -396,7 +431,7 @@ namespace md2visio.GUI.Forms
 
             var exitButton = new Button
             {
-                Text = "❌ 退出",
+                Text = UiStrings.Get("Exit"),
                 Dock = DockStyle.Fill,
                 BackColor = Color.LightCoral,
                 Margin = new Padding(0, 0, 5, 0)
@@ -406,10 +441,10 @@ namespace md2visio.GUI.Forms
             // 状态标签
             _statusLabel = new Label
             {
-                Text = "就绪",
+                Text = UiStrings.Get("Ready"),
                 Dock = DockStyle.Fill,
                 TextAlign = ContentAlignment.MiddleLeft,
-                Font = new Font("Microsoft YaHei UI", 9)
+                Font = UiFont(9)
             };
 
             // 进度条
@@ -430,11 +465,12 @@ namespace md2visio.GUI.Forms
                 Text = "© konbakuyomu",
                 Dock = DockStyle.Fill,
                 TextAlign = ContentAlignment.MiddleRight,
-                Font = new Font("Microsoft YaHei UI", 9)
+                Font = UiFont(9)
             };
             authorLabel.Links.Add(0, authorLabel.Text.Length, "https://github.com/konbakuyomu/md2visio-gui/");
             authorLabel.LinkClicked += (s, e) => {
-                Process.Start(new ProcessStartInfo(e.Link.LinkData.ToString()) { UseShellExecute = true });
+                if (e.Link?.LinkData is string url)
+                    Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
             };
 
             container.Controls.Add(authorLabel, 5, 0);
@@ -484,7 +520,7 @@ namespace md2visio.GUI.Forms
                 }
                 else
                 {
-                    MessageBox.Show("请选择 .md 文件！", "错误", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    MessageBox.Show(UiStrings.Get("InvalidMarkdown"), UiStrings.Get("Error"), MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
             }
         }
@@ -498,8 +534,8 @@ namespace md2visio.GUI.Forms
         {
             using var dialog = new OpenFileDialog
             {
-                Filter = "Markdown 文件|*.md|所有文件|*.*",
-                Title = "选择 Markdown 文件"
+                Filter = UiStrings.Get("MarkdownFilter"),
+                Title = UiStrings.Get("SelectMarkdown")
             };
 
             if (dialog.ShowDialog() == DialogResult.OK)
@@ -512,7 +548,7 @@ namespace md2visio.GUI.Forms
         {
             using var dialog = new FolderBrowserDialog
             {
-                Description = "选择输出目录",
+                Description = UiStrings.Get("SelectOutputFolder"),
                 SelectedPath = _outputDirTextBox.Text
             };
 
@@ -526,13 +562,13 @@ namespace md2visio.GUI.Forms
         {
             if (string.IsNullOrEmpty(_selectedFilePath))
             {
-                MessageBox.Show("请先选择要转换的文件！", "提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(UiStrings.Get("ChooseInputFirst"), UiStrings.Get("Notice"), MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
 
             if (string.IsNullOrEmpty(_outputDirTextBox.Text))
             {
-                MessageBox.Show("请选择输出目录！", "提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(UiStrings.Get("ChooseOutputFirst"), UiStrings.Get("Notice"), MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
 
@@ -552,23 +588,23 @@ namespace md2visio.GUI.Forms
                 {
                     _openOutputButton.Enabled = true;
                     ShowUserMessage(
-                        $"转换成功！\n生成了 {result.OutputFiles?.Length} 个文件。",
-                        "成功",
+                        UiStrings.Format("ConversionSucceeded", result.OutputFiles?.Length ?? 0),
+                        UiStrings.Get("Success"),
                         MessageBoxIcon.Information);
                 }
                 else
                 {
                     ShowUserMessage(
-                        $"转换失败！\n错误: {result.ErrorMessage}",
-                        "错误",
+                        UiStrings.Format("ConversionFailed", result.ErrorMessage),
+                        UiStrings.Get("Error"),
                         MessageBoxIcon.Error);
                 }
             }
             catch (Exception ex)
             {
                 ShowUserMessage(
-                    $"转换过程中发生错误:\n{ex.Message}",
-                    "错误",
+                    UiStrings.Format("ConversionException", ex.Message),
+                    UiStrings.Get("Error"),
                     MessageBoxIcon.Error);
             }
             finally
@@ -602,14 +638,14 @@ namespace md2visio.GUI.Forms
         private void SetSelectedFile(string filePath)
         {
             _selectedFilePath = filePath;
-            _selectedFileLabel.Text = $"选中文件: {filePath}";
+            _selectedFileLabel.Text = UiStrings.Format("SelectedFile", filePath);
             _selectedFileLabel.ForeColor = Color.Green;
 
             // 检测图表类型
             var types = _conversionService.DetectMermaidTypes(filePath);
             if (types.Count > 0)
             {
-                LogMessage($"检测到图表类型: {string.Join(", ", types)}");
+                LogMessage(UiStrings.Format("DetectedTypes", string.Join(", ", types)));
             }
 
             UpdateUI();
@@ -624,12 +660,12 @@ namespace md2visio.GUI.Forms
             
             if (busy)
             {
-                _statusLabel.Text = "转换中...";
+                _statusLabel.Text = UiStrings.Get("Converting");
                 _progressBar.Value = 0;
             }
             else
             {
-                _statusLabel.Text = "就绪";
+                _statusLabel.Text = UiStrings.Get("Ready");
             }
         }
 
@@ -681,7 +717,7 @@ namespace md2visio.GUI.Forms
         private async void OnCheckVisioClick(object? sender, EventArgs e)
         {
             SetUIBusy(true);
-            _statusLabel.Text = "正在检查Visio环境...";
+            _statusLabel.Text = UiStrings.Get("CheckingVisio");
 
             try
             {
@@ -689,21 +725,21 @@ namespace md2visio.GUI.Forms
                 
                 if (result.IsSuccess)
                 {
-                    MessageBox.Show($"✅ Visio环境检查通过！\n\n{string.Join("\n", result.OutputFiles ?? new string[0])}", 
-                        "环境检查成功", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    _statusLabel.Text = "Visio环境正常";
+                    MessageBox.Show(UiStrings.Format("VisioCheckPassed", string.Join("\n", result.OutputFiles ?? [])),
+                        UiStrings.Get("VisioCheckSucceededTitle"), MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    _statusLabel.Text = UiStrings.Get("VisioAvailable");
                 }
                 else
                 {
-                    MessageBox.Show($"❌ Visio环境检查失败！\n\n{result.ErrorMessage}", 
-                        "环境检查失败", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    _statusLabel.Text = "Visio环境异常";
+                    MessageBox.Show(UiStrings.Format("VisioCheckFailed", result.ErrorMessage),
+                        UiStrings.Get("VisioCheckFailedTitle"), MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    _statusLabel.Text = UiStrings.Get("VisioUnavailable");
                 }
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"检查过程中发生异常：\n{ex.Message}", "异常", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                _statusLabel.Text = "检查异常";
+                MessageBox.Show(UiStrings.Format("CheckException", ex.Message), UiStrings.Get("ExceptionTitle"), MessageBoxButtons.OK, MessageBoxIcon.Error);
+                _statusLabel.Text = UiStrings.Get("CheckFailed");
             }
             finally
             {
@@ -717,5 +753,49 @@ namespace md2visio.GUI.Forms
             _conversionService.Dispose();
             base.OnFormClosing(e);
         }
+
+        private void OnLanguageChanged(object? sender, EventArgs e)
+        {
+            if (_changingLanguage || _languageComboBox.SelectedItem is not LanguageChoice choice ||
+                choice.CultureName == CultureSettings.CurrentCultureName)
+                return;
+
+            var outputDirectory = _outputDirTextBox.Text;
+            var fileName = _fileNameTextBox.Text;
+            var showVisio = _showVisioCheckBox.Checked;
+            var silentOverwrite = _silentOverwriteCheckBox.Checked;
+            var log = _logTextBox.Text;
+
+            _changingLanguage = true;
+            CultureSettings.SaveAndApply(choice.CultureName);
+            SuspendLayout();
+            var oldControls = Controls.Cast<Control>().ToArray();
+            Controls.Clear();
+            foreach (var control in oldControls)
+                control.Dispose();
+            InitializeComponent();
+            SetupEventHandlers();
+            _outputDirTextBox.Text = outputDirectory;
+            _fileNameTextBox.Text = fileName;
+            _showVisioCheckBox.Checked = showVisio;
+            _silentOverwriteCheckBox.Checked = silentOverwrite;
+            _logTextBox.Text = log;
+            if (!string.IsNullOrEmpty(_selectedFilePath))
+            {
+                _selectedFileLabel.Text = UiStrings.Format("SelectedFile", _selectedFilePath);
+                _selectedFileLabel.ForeColor = Color.Green;
+            }
+            UpdateUI();
+            ResumeLayout(true);
+            _changingLanguage = false;
+        }
+
+        private sealed record LanguageChoice(string CultureName, string DisplayName)
+        {
+            public override string ToString() => DisplayName;
+        }
+
+        private static Font UiFont(float size, FontStyle style = FontStyle.Regular) =>
+            new((SystemFonts.MessageBoxFont ?? SystemFonts.DefaultFont).FontFamily, size, style);
     }
 } 

--- a/md2visio.GUI/Forms/MainForm.cs
+++ b/md2visio.GUI/Forms/MainForm.cs
@@ -220,7 +220,7 @@ namespace md2visio.GUI.Forms
 
             // 输出目录
             var outputDirLabel = new Label { Text = UiStrings.Get("OutputDirectory"), TextAlign = ContentAlignment.MiddleRight, Dock = DockStyle.Fill, Font = SystemFonts.MessageBoxFont };
-            _outputDirTextBox = new TextBox { Text = Environment.GetFolderPath(Environment.SpecialFolder.Desktop), Dock = DockStyle.Fill, Font = UiFont(9) };
+            _outputDirTextBox = new TextBox { Text = OutputDirectorySettings.Load(), Dock = DockStyle.Fill, Font = UiFont(9) };
             _selectDirButton = new Button { Text = UiStrings.Get("SelectDirectory"), Dock = DockStyle.Fill, Margin = new Padding(5, 0, 0, 0), Font = SystemFonts.MessageBoxFont };
 
             // 文件名
@@ -555,6 +555,7 @@ namespace md2visio.GUI.Forms
             if (dialog.ShowDialog() == DialogResult.OK)
             {
                 _outputDirTextBox.Text = dialog.SelectedPath;
+                OutputDirectorySettings.Save(dialog.SelectedPath);
             }
         }
 
@@ -571,6 +572,8 @@ namespace md2visio.GUI.Forms
                 MessageBox.Show(UiStrings.Get("ChooseOutputFirst"), UiStrings.Get("Notice"), MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
             }
+
+            OutputDirectorySettings.Save(_outputDirTextBox.Text);
 
             SetUIBusy(true);
 
@@ -749,6 +752,7 @@ namespace md2visio.GUI.Forms
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            OutputDirectorySettings.Save(_outputDirTextBox.Text);
             // 释放服务持有的资源，例如Visio COM对象
             _conversionService.Dispose();
             base.OnFormClosing(e);

--- a/md2visio.GUI/Localization/CultureSettings.cs
+++ b/md2visio.GUI/Localization/CultureSettings.cs
@@ -1,0 +1,72 @@
+using System.Globalization;
+
+namespace md2visio.GUI.Localization;
+
+internal static class CultureSettings
+{
+    private const string LanguageEnvironmentVariable = "MD2VISIO_LANGUAGE";
+    private const string SettingsFileName = "language.txt";
+    private static readonly string[] SupportedCultures = ["en", "zh-CN"];
+
+    public static string CurrentCultureName =>
+        CultureInfo.CurrentUICulture.Name.StartsWith("zh", StringComparison.OrdinalIgnoreCase)
+            ? "zh-CN"
+            : "en";
+
+    public static void ApplySavedCulture()
+    {
+        var requestedCulture = Environment.GetEnvironmentVariable(LanguageEnvironmentVariable);
+        if (string.IsNullOrWhiteSpace(requestedCulture))
+        {
+            try
+            {
+                var settingsPath = GetSettingsPath();
+                if (File.Exists(settingsPath))
+                    requestedCulture = File.ReadAllText(settingsPath).Trim();
+            }
+            catch
+            {
+                // A read-only profile should not prevent the application from starting.
+            }
+        }
+
+        SetCulture(Normalize(requestedCulture ?? CultureInfo.CurrentUICulture.Name));
+    }
+
+    public static void SaveAndApply(string cultureName)
+    {
+        cultureName = Normalize(cultureName);
+        SetCulture(cultureName);
+
+        try
+        {
+            var settingsPath = GetSettingsPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+            File.WriteAllText(settingsPath, cultureName);
+        }
+        catch
+        {
+            // The selected language still applies for this session.
+        }
+    }
+
+    private static void SetCulture(string cultureName)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+    }
+
+    private static string Normalize(string cultureName) =>
+        SupportedCultures.Contains(cultureName, StringComparer.OrdinalIgnoreCase) ||
+        cultureName.StartsWith("zh", StringComparison.OrdinalIgnoreCase)
+            ? cultureName.StartsWith("zh", StringComparison.OrdinalIgnoreCase) ? "zh-CN" : "en"
+            : "en";
+
+    private static string GetSettingsPath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "md2visio",
+        SettingsFileName);
+}

--- a/md2visio.GUI/Localization/OutputDirectorySettings.cs
+++ b/md2visio.GUI/Localization/OutputDirectorySettings.cs
@@ -1,0 +1,46 @@
+namespace md2visio.GUI.Localization;
+
+internal static class OutputDirectorySettings
+{
+    private const string SettingsFileName = "output-directory.txt";
+
+    public static string Load()
+    {
+        var fallback = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+
+        try
+        {
+            var settingsPath = GetSettingsPath();
+            if (!File.Exists(settingsPath)) return fallback;
+
+            var savedDirectory = File.ReadAllText(settingsPath).Trim();
+            return Directory.Exists(savedDirectory) ? savedDirectory : fallback;
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+
+    public static void Save(string? directory)
+    {
+        if (string.IsNullOrWhiteSpace(directory)) return;
+
+        try
+        {
+            var fullPath = Path.GetFullPath(directory.Trim());
+            var settingsPath = GetSettingsPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(settingsPath)!);
+            File.WriteAllText(settingsPath, fullPath);
+        }
+        catch
+        {
+            // A read-only profile should not interrupt normal application use.
+        }
+    }
+
+    private static string GetSettingsPath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "md2visio",
+        SettingsFileName);
+}

--- a/md2visio.GUI/Localization/UiStrings.cs
+++ b/md2visio.GUI/Localization/UiStrings.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+using System.Resources;
+
+namespace md2visio.GUI.Localization;
+
+internal static class UiStrings
+{
+    private static readonly ResourceManager Resources =
+        new("md2visio.GUI.Resources.Strings", typeof(UiStrings).Assembly);
+
+    public static string Get(string key) =>
+        Resources.GetString(key, CultureInfo.CurrentUICulture) ?? $"[{key}]";
+
+    public static string Format(string key, params object?[] args) =>
+        string.Format(CultureInfo.CurrentCulture, Get(key), args);
+}

--- a/md2visio.GUI/Program.cs
+++ b/md2visio.GUI/Program.cs
@@ -1,4 +1,5 @@
 using md2visio.GUI.Forms;
+using md2visio.GUI.Localization;
 
 namespace md2visio.GUI;
 
@@ -10,6 +11,8 @@ internal static class Program
     [STAThread]
     static void Main()
     {
+        CultureSettings.ApplySavedCulture();
+
         // 确保COM线程模式
         System.Threading.Thread.CurrentThread.SetApartmentState(System.Threading.ApartmentState.STA);
         

--- a/md2visio.GUI/Resources/Strings.resx
+++ b/md2visio.GUI/Resources/Strings.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="AppTitle" xml:space="preserve"><value>md2visio - Mermaid to Visio Converter</value></data>
+  <data name="HeaderTitle" xml:space="preserve"><value>📄 md2visio - Mermaid to Visio Converter</value></data>
+  <data name="Language" xml:space="preserve"><value>Language:</value></data>
+  <data name="English" xml:space="preserve"><value>English</value></data>
+  <data name="Chinese" xml:space="preserve"><value>中文</value></data>
+  <data name="InputFile" xml:space="preserve"><value>📁 Input file</value></data>
+  <data name="DropHint" xml:space="preserve"><value>Drop a .md file here or click Browse</value></data>
+  <data name="BrowseFiles" xml:space="preserve"><value>Browse...</value></data>
+  <data name="NoFileSelected" xml:space="preserve"><value>No file selected</value></data>
+  <data name="SelectedFile" xml:space="preserve"><value>Selected file: {0}</value></data>
+  <data name="OutputSettings" xml:space="preserve"><value>📂 Output settings</value></data>
+  <data name="OutputDirectory" xml:space="preserve"><value>Output folder:</value></data>
+  <data name="SelectDirectory" xml:space="preserve"><value>Select folder...</value></data>
+  <data name="FileName" xml:space="preserve"><value>File name:</value></data>
+  <data name="ConversionOptions" xml:space="preserve"><value>⚙️ Conversion options</value></data>
+  <data name="ShowVisio" xml:space="preserve"><value>Show Visio window</value></data>
+  <data name="SilentOverwrite" xml:space="preserve"><value>Overwrite files without prompting</value></data>
+  <data name="SupportedTypes" xml:space="preserve"><value>📊 Supported diagram types</value></data>
+  <data name="Flowchart" xml:space="preserve"><value>✅ Flowchart</value></data>
+  <data name="PieChart" xml:space="preserve"><value>✅ Pie chart</value></data>
+  <data name="UserJourney" xml:space="preserve"><value>✅ User journey</value></data>
+  <data name="PacketDiagram" xml:space="preserve"><value>✅ Packet diagram</value></data>
+  <data name="XYChart" xml:space="preserve"><value>✅ XY chart</value></data>
+  <data name="SequenceDiagram" xml:space="preserve"><value>✅ Sequence diagram</value></data>
+  <data name="EntityRelationshipDiagram" xml:space="preserve"><value>✅ Entity relationship diagram</value></data>
+  <data name="ConversionLog" xml:space="preserve"><value>📝 Conversion log</value></data>
+  <data name="ClearLog" xml:space="preserve"><value>Clear log</value></data>
+  <data name="StartConversion" xml:space="preserve"><value>🚀 Convert</value></data>
+  <data name="CheckVisio" xml:space="preserve"><value>🔍 Check Visio</value></data>
+  <data name="OpenOutput" xml:space="preserve"><value>📁 Open output folder</value></data>
+  <data name="Exit" xml:space="preserve"><value>❌ Exit</value></data>
+  <data name="Ready" xml:space="preserve"><value>Ready</value></data>
+  <data name="Converting" xml:space="preserve"><value>Converting...</value></data>
+  <data name="Error" xml:space="preserve"><value>Error</value></data>
+  <data name="Notice" xml:space="preserve"><value>Notice</value></data>
+  <data name="Success" xml:space="preserve"><value>Success</value></data>
+  <data name="InvalidMarkdown" xml:space="preserve"><value>Please select a .md file.</value></data>
+  <data name="MarkdownFilter" xml:space="preserve"><value>Markdown files|*.md|All files|*.*</value></data>
+  <data name="SelectMarkdown" xml:space="preserve"><value>Select a Markdown file</value></data>
+  <data name="SelectOutputFolder" xml:space="preserve"><value>Select an output folder</value></data>
+  <data name="ChooseInputFirst" xml:space="preserve"><value>Select a file to convert first.</value></data>
+  <data name="ChooseOutputFirst" xml:space="preserve"><value>Select an output folder.</value></data>
+  <data name="ConversionSucceeded" xml:space="preserve"><value>Conversion succeeded!&#xA;Generated {0} file(s).</value></data>
+  <data name="ConversionFailed" xml:space="preserve"><value>Conversion failed!&#xA;Error: {0}</value></data>
+  <data name="ConversionException" xml:space="preserve"><value>An error occurred during conversion:&#xA;{0}</value></data>
+  <data name="DetectedTypes" xml:space="preserve"><value>Detected diagram types: {0}</value></data>
+  <data name="CheckingVisio" xml:space="preserve"><value>Checking the Visio environment...</value></data>
+  <data name="VisioCheckPassed" xml:space="preserve"><value>✅ Visio environment check passed!&#xA;&#xA;{0}</value></data>
+  <data name="VisioCheckSucceededTitle" xml:space="preserve"><value>Environment check passed</value></data>
+  <data name="VisioAvailable" xml:space="preserve"><value>Visio is available</value></data>
+  <data name="VisioCheckFailed" xml:space="preserve"><value>❌ Visio environment check failed!&#xA;&#xA;{0}</value></data>
+  <data name="VisioCheckFailedTitle" xml:space="preserve"><value>Environment check failed</value></data>
+  <data name="VisioUnavailable" xml:space="preserve"><value>Visio is unavailable</value></data>
+  <data name="CheckException" xml:space="preserve"><value>An error occurred during the check:&#xA;{0}</value></data>
+  <data name="ExceptionTitle" xml:space="preserve"><value>Unexpected error</value></data>
+  <data name="CheckFailed" xml:space="preserve"><value>Check failed</value></data>
+</root>

--- a/md2visio.GUI/Resources/Strings.zh-CN.resx
+++ b/md2visio.GUI/Resources/Strings.zh-CN.resx
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="AppTitle" xml:space="preserve"><value>md2visio - Mermaid 转 Visio 工具</value></data>
+  <data name="HeaderTitle" xml:space="preserve"><value>📄 md2visio - Mermaid 转 Visio 工具</value></data>
+  <data name="Language" xml:space="preserve"><value>语言:</value></data>
+  <data name="English" xml:space="preserve"><value>English</value></data>
+  <data name="Chinese" xml:space="preserve"><value>中文</value></data>
+  <data name="InputFile" xml:space="preserve"><value>📁 输入文件</value></data>
+  <data name="DropHint" xml:space="preserve"><value>将 .md 文件拖拽到此处或点击浏览选择</value></data>
+  <data name="BrowseFiles" xml:space="preserve"><value>浏览文件...</value></data>
+  <data name="NoFileSelected" xml:space="preserve"><value>未选择文件</value></data>
+  <data name="SelectedFile" xml:space="preserve"><value>选中文件: {0}</value></data>
+  <data name="OutputSettings" xml:space="preserve"><value>📂 输出设置</value></data>
+  <data name="OutputDirectory" xml:space="preserve"><value>输出目录:</value></data>
+  <data name="SelectDirectory" xml:space="preserve"><value>选择目录...</value></data>
+  <data name="FileName" xml:space="preserve"><value>文件名:</value></data>
+  <data name="ConversionOptions" xml:space="preserve"><value>⚙️ 转换选项</value></data>
+  <data name="ShowVisio" xml:space="preserve"><value>显示 Visio 窗口</value></data>
+  <data name="SilentOverwrite" xml:space="preserve"><value>静默覆盖文件</value></data>
+  <data name="SupportedTypes" xml:space="preserve"><value>📊 支持的图表类型</value></data>
+  <data name="Flowchart" xml:space="preserve"><value>✅ 流程图</value></data>
+  <data name="PieChart" xml:space="preserve"><value>✅ 饼图</value></data>
+  <data name="UserJourney" xml:space="preserve"><value>✅ 用户旅程图</value></data>
+  <data name="PacketDiagram" xml:space="preserve"><value>✅ 数据包图</value></data>
+  <data name="XYChart" xml:space="preserve"><value>✅ XY图表</value></data>
+  <data name="SequenceDiagram" xml:space="preserve"><value>✅ 时序图</value></data>
+  <data name="EntityRelationshipDiagram" xml:space="preserve"><value>✅ 实体关系图</value></data>
+  <data name="ConversionLog" xml:space="preserve"><value>📝 转换日志</value></data>
+  <data name="ClearLog" xml:space="preserve"><value>清空日志</value></data>
+  <data name="StartConversion" xml:space="preserve"><value>🚀 开始转换</value></data>
+  <data name="CheckVisio" xml:space="preserve"><value>🔍 检查 Visio</value></data>
+  <data name="OpenOutput" xml:space="preserve"><value>📁 打开输出目录</value></data>
+  <data name="Exit" xml:space="preserve"><value>❌ 退出</value></data>
+  <data name="Ready" xml:space="preserve"><value>就绪</value></data>
+  <data name="Converting" xml:space="preserve"><value>转换中...</value></data>
+  <data name="Error" xml:space="preserve"><value>错误</value></data>
+  <data name="Notice" xml:space="preserve"><value>提示</value></data>
+  <data name="Success" xml:space="preserve"><value>成功</value></data>
+  <data name="InvalidMarkdown" xml:space="preserve"><value>请选择 .md 文件！</value></data>
+  <data name="MarkdownFilter" xml:space="preserve"><value>Markdown 文件|*.md|所有文件|*.*</value></data>
+  <data name="SelectMarkdown" xml:space="preserve"><value>选择 Markdown 文件</value></data>
+  <data name="SelectOutputFolder" xml:space="preserve"><value>选择输出目录</value></data>
+  <data name="ChooseInputFirst" xml:space="preserve"><value>请先选择要转换的文件！</value></data>
+  <data name="ChooseOutputFirst" xml:space="preserve"><value>请选择输出目录！</value></data>
+  <data name="ConversionSucceeded" xml:space="preserve"><value>转换成功！&#xA;生成了 {0} 个文件。</value></data>
+  <data name="ConversionFailed" xml:space="preserve"><value>转换失败！&#xA;错误: {0}</value></data>
+  <data name="ConversionException" xml:space="preserve"><value>转换过程中发生错误:&#xA;{0}</value></data>
+  <data name="DetectedTypes" xml:space="preserve"><value>检测到图表类型: {0}</value></data>
+  <data name="CheckingVisio" xml:space="preserve"><value>正在检查 Visio 环境...</value></data>
+  <data name="VisioCheckPassed" xml:space="preserve"><value>✅ Visio 环境检查通过！&#xA;&#xA;{0}</value></data>
+  <data name="VisioCheckSucceededTitle" xml:space="preserve"><value>环境检查成功</value></data>
+  <data name="VisioAvailable" xml:space="preserve"><value>Visio 环境正常</value></data>
+  <data name="VisioCheckFailed" xml:space="preserve"><value>❌ Visio 环境检查失败！&#xA;&#xA;{0}</value></data>
+  <data name="VisioCheckFailedTitle" xml:space="preserve"><value>环境检查失败</value></data>
+  <data name="VisioUnavailable" xml:space="preserve"><value>Visio 环境异常</value></data>
+  <data name="CheckException" xml:space="preserve"><value>检查过程中发生异常：&#xA;{0}</value></data>
+  <data name="ExceptionTitle" xml:space="preserve"><value>异常</value></data>
+  <data name="CheckFailed" xml:space="preserve"><value>检查异常</value></data>
+</root>

--- a/md2visio.GUI/Services/ConversionService.cs
+++ b/md2visio.GUI/Services/ConversionService.cs
@@ -1,4 +1,5 @@
 using md2visio.Api;
+using md2visio.Localization;
 
 namespace md2visio.GUI.Services
 {
@@ -12,7 +13,16 @@ namespace md2visio.GUI.Services
 
         private IMd2VisioConverter? _converter;
         private bool _disposed = false;
+        private bool _automationTimedOut;
         private readonly object _lock = new object();
+        private readonly object _logFileLock = new object();
+        private static readonly TimeSpan VisioStartupTimeout = TimeSpan.FromSeconds(30);
+
+        public string LogFilePath { get; } = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "md2visio",
+            "logs",
+            $"md2visio-{DateTime.Now:yyyyMMdd}.log");
 
         /// <summary>
         /// 转换 MD 文件到 Visio（异步）
@@ -24,7 +34,28 @@ namespace md2visio.GUI.Services
             bool showVisio = false,
             bool silentOverwrite = false)
         {
-            return await RunOnStaThread(() => Convert(inputFile, outputDir, fileName, showVisio, silentOverwrite));
+            if (_automationTimedOut)
+                return ConversionResult.Error(CoreStrings.Get("RestartAfterTimeout"));
+
+            var startupCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var conversionTask = RunOnStaThread(() => Convert(
+                inputFile,
+                outputDir,
+                fileName,
+                showVisio,
+                silentOverwrite,
+                startupCompleted));
+
+            var startupOrCompletion = Task.WhenAny(conversionTask, startupCompleted.Task);
+            if (await Task.WhenAny(startupOrCompletion, Task.Delay(VisioStartupTimeout)) != startupOrCompletion)
+            {
+                _automationTimedOut = true;
+                var message = CoreStrings.Format("VisioStartupTimeout", (int)VisioStartupTimeout.TotalSeconds);
+                ReportLog(message);
+                return ConversionResult.Error(message);
+            }
+
+            return await conversionTask;
         }
 
         private Task<ConversionResult> RunOnStaThread(Func<ConversionResult> work)
@@ -60,28 +91,29 @@ namespace md2visio.GUI.Services
             string outputDir,
             string? fileName,
             bool showVisio,
-            bool silentOverwrite)
+            bool silentOverwrite,
+            TaskCompletionSource<bool> startupCompleted)
         {
             try
             {
-                ReportProgress(0, "开始转换...");
-                ReportLog($"输入文件: {inputFile}");
-                ReportLog($"输出目录: {outputDir}");
+                ReportProgress(0, CoreStrings.Get("StartingConversion"));
+                ReportLog(CoreStrings.Format("InputFile", inputFile));
+                ReportLog(CoreStrings.Format("OutputDirectory", outputDir));
 
                 // 验证输入文件
                 if (!File.Exists(inputFile))
-                    return ConversionResult.Error($"输入文件不存在: {inputFile}");
+                    return ConversionResult.Error(CoreStrings.Format("InputMissing", inputFile));
 
                 if (!Path.GetExtension(inputFile).Equals(".md", StringComparison.OrdinalIgnoreCase))
-                    return ConversionResult.Error("输入文件必须是 .md 格式");
+                    return ConversionResult.Error(CoreStrings.Get("InputMustBeMarkdown"));
 
                 // 创建输出目录
                 Directory.CreateDirectory(outputDir);
-                ReportProgress(10, "准备转换环境...");
+                ReportProgress(10, CoreStrings.Get("PreparingEnvironment"));
 
                 // 构建输出路径
                 string outputPath = BuildOutputPath(outputDir, fileName);
-                ReportLog($"输出路径: {outputPath}");
+                ReportLog(CoreStrings.Format("OutputPath", outputPath));
 
                 // 创建转换请求
                 var request = new md2visio.Api.ConversionRequest(
@@ -89,14 +121,16 @@ namespace md2visio.GUI.Services
                     outputPath: outputPath,
                     showVisio: showVisio,
                     silentOverwrite: silentOverwrite,
-                    debug: true  // 保持调试模式以获取详细日志
+                    debug: false
                 );
 
                 // 创建进度报告器
-                var progress = new Progress<md2visio.Api.ConversionProgress>(p =>
+                var progress = new InlineProgress<md2visio.Api.ConversionProgress>(p =>
                 {
                     int guiProgress = MapProgress(p.Phase, p.Percentage);
                     ReportProgress(guiProgress, p.Message);
+                    if (p.Phase >= md2visio.Api.ConversionPhase.Parsing)
+                        startupCompleted.TrySetResult(true);
                 });
 
                 // 创建日志接收器
@@ -119,9 +153,10 @@ namespace md2visio.GUI.Services
                 }
 
                 // 执行转换
-                ReportLog("开始执行核心转换逻辑...");
+                ReportLog(CoreStrings.Get("ExecutingCore"));
                 var apiResult = _converter.Convert(request, progress, logSink);
-                ReportLog("核心转换逻辑执行完成");
+                if (apiResult.Success)
+                    ReportLog(CoreStrings.Get("CoreComplete"));
 
                 // 非显示模式立即释放资源
                 if (!showVisio)
@@ -136,8 +171,8 @@ namespace md2visio.GUI.Services
                 // 转换结果
                 if (apiResult.Success)
                 {
-                    ReportProgress(100, "转换完成!");
-                    ReportLog($"成功生成 {apiResult.OutputFiles.Length} 个文件:");
+                    ReportProgress(100, CoreStrings.Get("ConversionComplete"));
+                    ReportLog(CoreStrings.Format("GeneratedFiles", apiResult.OutputFiles.Length));
                     foreach (var file in apiResult.OutputFiles)
                     {
                         ReportLog($"  - {Path.GetFileName(file)}");
@@ -146,33 +181,29 @@ namespace md2visio.GUI.Services
                 }
                 else
                 {
-                    ReportLog($"转换失败: {apiResult.ErrorMessage}");
-                    return ConversionResult.Error(apiResult.ErrorMessage ?? "未知错误");
+                    ReportLog(CoreStrings.Format("ConversionFailed", apiResult.ErrorMessage));
+                    return ConversionResult.Error(apiResult.ErrorMessage ?? CoreStrings.Get("UnknownError"));
                 }
             }
             catch (NotImplementedException ex)
             {
-                ReportLog($"功能未实现: {ex.Message}");
-                return ConversionResult.Error($"该图表类型暂未支持: {ex.Message}");
+                ReportLog(CoreStrings.Format("FeatureNotImplemented", ex.Message));
+                return ConversionResult.Error(CoreStrings.Format("UnsupportedDiagram", ex.Message));
             }
             catch (System.Runtime.InteropServices.COMException ex)
             {
-                ReportLog($"COM异常: {ex.Message} (HRESULT: 0x{ex.HResult:X8})");
-                return ConversionResult.Error($"COM组件异常，可能的原因：\n" +
-                    "1. Microsoft Visio未正确安装或注册\n" +
-                    "2. Visio进程被锁定或权限不足\n" +
-                    "3. 系统COM组件损坏\n" +
-                    $"详细错误: {ex.Message}");
+                ReportLog(CoreStrings.Format("ComException", ex.Message, ex.HResult.ToString("X8")));
+                return ConversionResult.Error(CoreStrings.Format("ComExceptionHelp", ex.Message));
             }
             catch (Exception ex)
             {
-                ReportLog($"转换出错: {ex.Message}");
-                ReportLog($"异常类型: {ex.GetType().Name}");
+                ReportLog(CoreStrings.Format("ConversionFailed", ex.Message));
+                ReportLog(CoreStrings.Format("ErrorType", ex.GetType().Name));
                 if (ex.InnerException != null)
                 {
-                    ReportLog($"内部异常: {ex.InnerException.Message}");
+                    ReportLog(CoreStrings.Format("InnerException", ex.InnerException.Message));
                 }
-                return ConversionResult.Error($"转换失败: {ex.Message}");
+                return ConversionResult.Error(CoreStrings.Format("ConversionFailed", ex.Message));
             }
         }
 
@@ -252,7 +283,7 @@ namespace md2visio.GUI.Services
             }
             catch (Exception ex)
             {
-                ReportLog($"检测文件类型时出错: {ex.Message}");
+                ReportLog(CoreStrings.Format("DetectTypesError", ex.Message));
             }
 
             return types;
@@ -266,26 +297,22 @@ namespace md2visio.GUI.Services
             Microsoft.Office.Interop.Visio.Application? visioApp = null;
             try
             {
-                ReportLog("正在检查Visio环境...");
+                ReportLog(CoreStrings.Get("CheckingVisio"));
 
                 visioApp = new Microsoft.Office.Interop.Visio.Application();
                 var version = visioApp.Version;
-                ReportLog($"Visio可用，版本: {version}");
-                return ConversionResult.Success(new string[] { $"Visio版本: {version}" });
+                ReportLog(CoreStrings.Format("VisioAvailableVersion", version));
+                return ConversionResult.Success([CoreStrings.Format("VisioVersion", version)]);
             }
             catch (System.Runtime.InteropServices.COMException ex)
             {
-                ReportLog($"Visio不可用: {ex.Message}");
-                return ConversionResult.Error($"Visio环境检查失败：\n" +
-                    "1. 请确认Microsoft Visio已正确安装\n" +
-                    "2. 检查Visio是否已正确注册\n" +
-                    "3. 尝试手动启动Visio测试\n" +
-                    $"错误详情: {ex.Message}");
+                ReportLog(CoreStrings.Format("VisioUnavailableDetail", ex.Message));
+                return ConversionResult.Error(CoreStrings.Format("VisioCheckHelp", ex.Message));
             }
             catch (Exception ex)
             {
-                ReportLog($"环境检查异常: {ex.Message}");
-                return ConversionResult.Error($"环境检查失败: {ex.Message}");
+                ReportLog(CoreStrings.Format("EnvironmentCheckException", ex.Message));
+                return ConversionResult.Error(CoreStrings.Format("EnvironmentCheckFailed", ex.Message));
             }
             finally
             {
@@ -308,7 +335,25 @@ namespace md2visio.GUI.Services
 
         private void ReportLog(string message)
         {
-            LogMessage?.Invoke(this, new ConversionLogEventArgs(DateTime.Now, message));
+            var timestamp = DateTime.Now;
+            WriteLogFile(timestamp, message);
+            LogMessage?.Invoke(this, new ConversionLogEventArgs(timestamp, message));
+        }
+
+        private void WriteLogFile(DateTime timestamp, string message)
+        {
+            try
+            {
+                lock (_logFileLock)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(LogFilePath)!);
+                    File.AppendAllText(LogFilePath, $"[{timestamp:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}");
+                }
+            }
+            catch
+            {
+                // File logging must never interrupt conversion or UI logging.
+            }
         }
 
         public void Dispose()
@@ -373,6 +418,11 @@ namespace md2visio.GUI.Services
 
                 return $"{prefix} {message}";
             }
+        }
+
+        private sealed class InlineProgress<T>(Action<T> handler) : IProgress<T>
+        {
+            public void Report(T value) => handler(value);
         }
     }
 

--- a/md2visio.Tests/Graph/CompoundGraphLayoutTests.cs
+++ b/md2visio.Tests/Graph/CompoundGraphLayoutTests.cs
@@ -1,0 +1,82 @@
+using md2visio.struc.graph;
+
+namespace md2visio.Tests.Graph;
+
+public sealed class CompoundGraphLayoutTests
+{
+    [Fact]
+    public void Subgraph_InheritsParentDirection()
+    {
+        var parent = new md2visio.struc.graph.Graph { Direction = "TB" };
+
+        var child = new GSubgraph(parent);
+
+        Assert.Equal("TB", child.Direction);
+    }
+
+    [Fact]
+    public void Calculate_KeepsGroupsDisjointAndContainsTheirNodes()
+    {
+        LayoutNode[] nodes =
+        [
+            new("prospect", null, 1.2, 0.5, 0),
+            new("buy", null, 1.4, 0.5, 1),
+            new("m1", "marketing", 1.6, 0.5, 2),
+            new("m2", "marketing", 1.3, 0.5, 3),
+            new("s1", "sales", 1.4, 0.5, 4),
+            new("s2", "sales", 1.5, 0.5, 5)
+        ];
+        LayoutGroup[] groups =
+        [
+            new("marketing", null, "TB", 0),
+            new("sales", null, "TB", 1)
+        ];
+        LayoutEdge[] edges =
+        [
+            new("prospect", "buy"),
+            new("prospect", "m1"),
+            new("m1", "m2"),
+            new("m2", "s1"),
+            new("s1", "s2")
+        ];
+
+        var result = CompoundGraphLayout.Calculate(nodes, groups, edges, "TB");
+
+        AssertContains(result.Groups["marketing"], result.Nodes["m1"]);
+        AssertContains(result.Groups["marketing"], result.Nodes["m2"]);
+        AssertContains(result.Groups["sales"], result.Nodes["s1"]);
+        AssertContains(result.Groups["sales"], result.Nodes["s2"]);
+        Assert.False(Overlaps(result.Groups["marketing"], result.Groups["sales"]));
+        Assert.True(result.Nodes["prospect"].CenterY > result.Nodes["buy"].CenterY);
+    }
+
+    [Fact]
+    public void Calculate_CollapsesCyclesIntoOneRankWithoutCollisions()
+    {
+        LayoutNode[] nodes =
+        [
+            new("a", null, 1, 0.5, 0),
+            new("b", null, 1, 0.5, 1),
+            new("c", null, 1, 0.5, 2)
+        ];
+        LayoutEdge[] edges = [new("a", "b"), new("b", "a"), new("b", "c")];
+
+        var result = CompoundGraphLayout.Calculate(nodes, [], edges, "TB");
+
+        Assert.Equal(result.Nodes["a"].CenterY, result.Nodes["b"].CenterY, precision: 8);
+        Assert.False(Overlaps(result.Nodes["a"], result.Nodes["b"]));
+        Assert.True(result.Nodes["c"].CenterY < result.Nodes["b"].CenterY);
+    }
+
+    private static void AssertContains(LayoutRect outer, LayoutRect inner)
+    {
+        Assert.True(inner.CenterX - inner.Width / 2 >= outer.CenterX - outer.Width / 2);
+        Assert.True(inner.CenterX + inner.Width / 2 <= outer.CenterX + outer.Width / 2);
+        Assert.True(inner.CenterY - inner.Height / 2 >= outer.CenterY - outer.Height / 2);
+        Assert.True(inner.CenterY + inner.Height / 2 <= outer.CenterY + outer.Height / 2);
+    }
+
+    private static bool Overlaps(LayoutRect a, LayoutRect b) =>
+        Math.Abs(a.CenterX - b.CenterX) < (a.Width + b.Width) / 2 &&
+        Math.Abs(a.CenterY - b.CenterY) < (a.Height + b.Height) / 2;
+}

--- a/md2visio.Tests/Localization/CoreStringsTests.cs
+++ b/md2visio.Tests/Localization/CoreStringsTests.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using md2visio.Localization;
+
+namespace md2visio.Tests.Localization;
+
+[CollectionDefinition("Culture-sensitive tests", DisableParallelization = true)]
+public sealed class CultureSensitiveCollection;
+
+[Collection("Culture-sensitive tests")]
+public sealed class CoreStringsTests
+{
+    [Theory]
+    [InlineData("en", "Conversion complete!")]
+    [InlineData("zh-CN", "转换完成!")]
+    public void Get_UsesRequestedUiCulture(string cultureName, string expected)
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        var originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            var culture = CultureInfo.GetCultureInfo(cultureName);
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+
+            Assert.Equal(expected, CoreStrings.Get("ConversionComplete"));
+            Assert.DoesNotContain("[", CoreStrings.Format("GeneratedFiles", 2));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+}

--- a/md2visio.Tests/Visio/OutputFileAccessTests.cs
+++ b/md2visio.Tests/Visio/OutputFileAccessTests.cs
@@ -1,0 +1,33 @@
+using md2visio.vsdx.@base;
+
+namespace md2visio.Tests.VisioParsing;
+
+public sealed class OutputFileAccessTests
+{
+    [Fact]
+    public void Check_ReturnsWritableForMissingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"md2visio-{Guid.NewGuid():N}.vsdx");
+
+        Assert.Equal(OutputFileStatus.Writable, OutputFileAccess.Check(path));
+    }
+
+    [Fact]
+    public void Check_ReturnsInUseForExclusivelyLockedFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"md2visio-{Guid.NewGuid():N}.vsdx");
+        File.WriteAllText(path, "test");
+
+        try
+        {
+            using (var lockStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                Assert.Equal(OutputFileStatus.InUse, OutputFileAccess.Check(path));
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/md2visio.Tests/Visio/VisioValueParserTests.cs
+++ b/md2visio.Tests/Visio/VisioValueParserTests.cs
@@ -1,0 +1,23 @@
+using md2visio.vsdx.@base;
+
+namespace md2visio.Tests.VisioParsing;
+
+public sealed class VisioValueParserTests
+{
+    [Theory]
+    [InlineData("2.8222 mm.", 2.8222)]
+    [InlineData("2,8222 mm", 2.8222)]
+    [InlineData("9 pt.", 9)]
+    [InlineData("-1.25 in.", -1.25)]
+    [InlineData("1.2E-3 mm", 0.0012)]
+    public void ParseResult_AcceptsLocalizedVisioUnitStrings(string value, double expected)
+    {
+        Assert.Equal(expected, VisioValueParser.ParseResult(value), precision: 8);
+    }
+
+    [Fact]
+    public void ParseResult_RejectsMissingNumbers()
+    {
+        Assert.Throws<FormatException>(() => VisioValueParser.ParseResult("mm."));
+    }
+}

--- a/md2visio/Api/Md2VisioConverter.cs
+++ b/md2visio/Api/Md2VisioConverter.cs
@@ -1,4 +1,5 @@
 using md2visio.mermaid.cmn;
+using md2visio.Localization;
 using md2visio.struc.figure;
 using md2visio.vsdx.@base;
 using System.Reflection;
@@ -34,14 +35,14 @@ namespace md2visio.Api
             }
             catch (NotImplementedException ex)
             {
-                logger.Error($"不支持的图表类型: {ex.Message}");
-                return ConversionResult.Failed($"不支持的图表类型: {ex.Message}", ex);
+                logger.Error(CoreStrings.Format("UnsupportedDiagram", ex.Message));
+                return ConversionResult.Failed(CoreStrings.Format("UnsupportedDiagram", ex.Message), ex);
             }
             catch (System.Runtime.InteropServices.COMException ex)
             {
-                logger.Error($"Visio COM 错误: {ex.Message}");
+                logger.Error(CoreStrings.Format("VisioComErrorDetail", ex.Message));
                 return ConversionResult.Failed(
-                    "Visio COM 错误，请确保 Microsoft Visio 已正确安装。",
+                    CoreStrings.Get("VisioComError"),
                     ex);
             }
             catch (Exception ex)
@@ -49,12 +50,12 @@ namespace md2visio.Api
                 var root = UnwrapException(ex);
                 if (!ReferenceEquals(root, ex))
                 {
-                    logger.Error($"转换失败: {root.GetType().Name}: {root.Message}");
-                    return ConversionResult.Failed($"转换失败: {root.GetType().Name}: {root.Message}", ex);
+                    logger.Error(CoreStrings.Format("ConversionFailedTyped", root.GetType().Name, root.Message));
+                    return ConversionResult.Failed(CoreStrings.Format("ConversionFailedTyped", root.GetType().Name, root.Message), ex);
                 }
 
-                logger.Error($"转换失败: {ex.Message}");
-                return ConversionResult.Failed($"转换失败: {ex.Message}", ex);
+                logger.Error(CoreStrings.Format("ConversionFailed", ex.Message));
+                return ConversionResult.Failed(CoreStrings.Format("ConversionFailed", ex.Message), ex);
             }
         }
 
@@ -80,18 +81,18 @@ namespace md2visio.Api
             ILogSink logger)
         {
             // Step 1: 验证输入
-            progress?.Report(new ConversionProgress(0, "验证输入...", ConversionPhase.Starting));
-            logger.Info($"输入文件: {request.InputPath}");
-            logger.Info($"输出路径: {request.OutputPath}");
+            progress?.Report(new ConversionProgress(0, CoreStrings.Get("ValidatingInput"), ConversionPhase.Starting));
+            logger.Info(CoreStrings.Format("InputFile", request.InputPath));
+            logger.Info(CoreStrings.Format("OutputPath", request.OutputPath));
 
             if (!File.Exists(request.InputPath))
             {
-                return ConversionResult.Failed($"输入文件不存在: {request.InputPath}");
+                return ConversionResult.Failed(CoreStrings.Format("InputMissing", request.InputPath));
             }
 
             if (!Path.GetExtension(request.InputPath).Equals(".md", StringComparison.OrdinalIgnoreCase))
             {
-                return ConversionResult.Failed("输入文件必须是 .md 格式");
+                return ConversionResult.Failed(CoreStrings.Get("InputMustBeMarkdown"));
             }
 
             // 确保输出目录存在
@@ -102,19 +103,19 @@ namespace md2visio.Api
             if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
             {
                 Directory.CreateDirectory(outputDir);
-                logger.Debug($"创建输出目录: {outputDir}");
+                logger.Debug(CoreStrings.Format("CreatedOutputDirectory", outputDir));
             }
 
             // Step 2: 创建转换上下文和 Visio 会话
-            progress?.Report(new ConversionProgress(20, "初始化 Visio...", ConversionPhase.Starting));
-            logger.Info("初始化转换上下文...");
+            progress?.Report(new ConversionProgress(20, CoreStrings.Get("InitializingVisio"), ConversionPhase.Starting));
+            logger.Info(CoreStrings.Get("InitializingContext"));
 
             var context = new ConversionContext(request, logger);
             _session = new VisioSession(request.ShowVisio);
 
             // Step 3: 解析 Mermaid 内容
-            progress?.Report(new ConversionProgress(30, "解析 Mermaid 内容...", ConversionPhase.Parsing));
-            logger.Info("解析 Mermaid 内容...");
+            progress?.Report(new ConversionProgress(30, CoreStrings.Get("ParsingMermaid"), ConversionPhase.Parsing));
+            logger.Info(CoreStrings.Get("ParsingMermaid"));
 
             var synContext = new SynContext(request.InputPath);
             SttMermaidStart.Run(synContext);
@@ -125,14 +126,14 @@ namespace md2visio.Api
             }
 
             // Step 4: 构建图表
-            progress?.Report(new ConversionProgress(50, "构建图表结构...", ConversionPhase.Building));
-            logger.Info("构建图表结构...");
+            progress?.Report(new ConversionProgress(50, CoreStrings.Get("BuildingDiagram"), ConversionPhase.Building));
+            logger.Info(CoreStrings.Get("BuildingDiagram"));
 
             var factory = new FigureBuilderFactory(synContext.NewSttIterator(), context, _session);
 
             // Step 5: 渲染到 Visio
-            progress?.Report(new ConversionProgress(70, "渲染到 Visio...", ConversionPhase.Rendering));
-            logger.Info("渲染到 Visio 格式...");
+            progress?.Report(new ConversionProgress(70, CoreStrings.Get("RenderingVisio"), ConversionPhase.Rendering));
+            logger.Info(CoreStrings.Get("RenderingVisioFormat"));
 
             factory.Build(request.OutputPath);
 
@@ -147,7 +148,7 @@ namespace md2visio.Api
             }
 
             // Step 6: 如果不显示 Visio 则清理
-            progress?.Report(new ConversionProgress(90, "保存输出...", ConversionPhase.Saving));
+            progress?.Report(new ConversionProgress(90, CoreStrings.Get("SavingOutput"), ConversionPhase.Saving));
 
             if (!request.ShowVisio)
             {
@@ -156,13 +157,13 @@ namespace md2visio.Api
             }
 
             // Step 7: 收集输出文件并提供详细反馈
-            progress?.Report(new ConversionProgress(100, "转换完成!", ConversionPhase.Completed));
+            progress?.Report(new ConversionProgress(100, CoreStrings.Get("ConversionComplete"), ConversionPhase.Completed));
 
             var outputFiles = CollectOutputFiles(request);
 
             if (outputFiles.Length > 0)
             {
-                logger.Info($"生成 {outputFiles.Length} 个文件:");
+                logger.Info(CoreStrings.Format("GeneratedFiles", outputFiles.Length));
                 foreach (var file in outputFiles)
                 {
                     logger.Info($"  - {Path.GetFileName(file)}");
@@ -178,20 +179,16 @@ namespace md2visio.Api
                     if (factory.UnsupportedTypes.Count > 0)
                     {
                         var unsupported = string.Join(", ", factory.UnsupportedTypes);
-                        return ConversionResult.Failed(
-                            $"文件中包含不支持的图表类型: {unsupported}\n" +
-                            $"当前支持: {supportedTypes}");
+                        return ConversionResult.Failed(CoreStrings.Format("UnsupportedTypesInFile", unsupported, supportedTypes));
                     }
                     else
                     {
-                        return ConversionResult.Failed(
-                            "文件中未找到有效的 Mermaid 图表。\n" +
-                            "请确保使用 ```mermaid ... ``` 格式包裹图表代码。");
+                        return ConversionResult.Failed(CoreStrings.Get("NoValidDiagram"));
                     }
                 }
 
-                logger.Warning("转换完成但未找到输出文件。");
-                return ConversionResult.Failed("转换完成但未生成输出文件。请检查输出路径和权限设置。");
+                logger.Warning(CoreStrings.Get("NoOutputWarning"));
+                return ConversionResult.Failed(CoreStrings.Get("NoOutputError"));
             }
         }
 

--- a/md2visio/Api/Md2VisioConverter.cs
+++ b/md2visio/Api/Md2VisioConverter.cs
@@ -95,6 +95,16 @@ namespace md2visio.Api
                 return ConversionResult.Failed(CoreStrings.Get("InputMustBeMarkdown"));
             }
 
+            // Fail before Visio startup/rendering when an explicitly named output file
+            // cannot be overwritten. The final save repeats this check to cover races.
+            if (request.SilentOverwrite &&
+                request.OutputPath.EndsWith(".vsdx", StringComparison.OrdinalIgnoreCase))
+            {
+                var outputStatus = OutputFileAccess.Check(request.OutputPath);
+                if (outputStatus != OutputFileStatus.Writable)
+                    return ConversionResult.Failed(OutputFileAccess.GetMessage(outputStatus, request.OutputPath));
+            }
+
             // 确保输出目录存在
             string? outputDir = request.OutputPath.EndsWith(".vsdx", StringComparison.OrdinalIgnoreCase)
                 ? Path.GetDirectoryName(request.OutputPath)

--- a/md2visio/Localization/CoreStrings.cs
+++ b/md2visio/Localization/CoreStrings.cs
@@ -1,0 +1,16 @@
+using System.Globalization;
+using System.Resources;
+
+namespace md2visio.Localization;
+
+public static class CoreStrings
+{
+    private static readonly ResourceManager Resources =
+        new("md2visio.Resources.Strings", typeof(CoreStrings).Assembly);
+
+    public static string Get(string key) =>
+        Resources.GetString(key, CultureInfo.CurrentUICulture) ?? $"[{key}]";
+
+    public static string Format(string key, params object?[] args) =>
+        string.Format(CultureInfo.CurrentCulture, Get(key), args);
+}

--- a/md2visio/Properties/AssemblyInfo.cs
+++ b/md2visio/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("md2visio.Tests")]

--- a/md2visio/Resources/Strings.resx
+++ b/md2visio/Resources/Strings.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="UnsupportedDiagram" xml:space="preserve"><value>Unsupported diagram type: {0}</value></data>
+  <data name="VisioComErrorDetail" xml:space="preserve"><value>Visio COM error: {0}</value></data>
+  <data name="VisioComError" xml:space="preserve"><value>Visio COM error. Make sure Microsoft Visio is installed correctly.</value></data>
+  <data name="ConversionFailed" xml:space="preserve"><value>Conversion failed: {0}</value></data>
+  <data name="ConversionFailedTyped" xml:space="preserve"><value>Conversion failed: {0}: {1}</value></data>
+  <data name="ValidatingInput" xml:space="preserve"><value>Validating input...</value></data>
+  <data name="InputFile" xml:space="preserve"><value>Input file: {0}</value></data>
+  <data name="OutputPath" xml:space="preserve"><value>Output path: {0}</value></data>
+  <data name="InputMissing" xml:space="preserve"><value>Input file does not exist: {0}</value></data>
+  <data name="InputMustBeMarkdown" xml:space="preserve"><value>Input file must use the .md extension.</value></data>
+  <data name="CreatedOutputDirectory" xml:space="preserve"><value>Created output directory: {0}</value></data>
+  <data name="InitializingVisio" xml:space="preserve"><value>Initializing Visio...</value></data>
+  <data name="InitializingContext" xml:space="preserve"><value>Initializing conversion context...</value></data>
+  <data name="ParsingMermaid" xml:space="preserve"><value>Parsing Mermaid content...</value></data>
+  <data name="BuildingDiagram" xml:space="preserve"><value>Building diagram structure...</value></data>
+  <data name="RenderingVisio" xml:space="preserve"><value>Rendering to Visio...</value></data>
+  <data name="RenderingVisioFormat" xml:space="preserve"><value>Rendering in Visio format...</value></data>
+  <data name="SavingOutput" xml:space="preserve"><value>Saving output...</value></data>
+  <data name="ConversionComplete" xml:space="preserve"><value>Conversion complete!</value></data>
+  <data name="GeneratedFiles" xml:space="preserve"><value>Generated {0} file(s):</value></data>
+  <data name="UnsupportedTypesInFile" xml:space="preserve"><value>The file contains unsupported diagram types: {0}&#xA;Currently supported: {1}</value></data>
+  <data name="NoValidDiagram" xml:space="preserve"><value>No valid Mermaid diagram was found in the file.&#xA;Make sure diagram code is enclosed in a ```mermaid ... ``` block.</value></data>
+  <data name="NoOutputWarning" xml:space="preserve"><value>Conversion completed but no output file was found.</value></data>
+  <data name="NoOutputError" xml:space="preserve"><value>Conversion completed without generating an output file. Check the output path and permissions.</value></data>
+  <data name="StartingConversion" xml:space="preserve"><value>Starting conversion...</value></data>
+  <data name="OutputDirectory" xml:space="preserve"><value>Output directory: {0}</value></data>
+  <data name="PreparingEnvironment" xml:space="preserve"><value>Preparing the conversion environment...</value></data>
+  <data name="ExecutingCore" xml:space="preserve"><value>Running the core conversion...</value></data>
+  <data name="CoreComplete" xml:space="preserve"><value>Core conversion completed.</value></data>
+  <data name="UnknownError" xml:space="preserve"><value>Unknown error</value></data>
+  <data name="FeatureNotImplemented" xml:space="preserve"><value>Feature not implemented: {0}</value></data>
+  <data name="ComException" xml:space="preserve"><value>COM exception: {0} (HRESULT: 0x{1})</value></data>
+  <data name="ComExceptionHelp" xml:space="preserve"><value>A COM component error occurred. Possible causes:&#xA;1. Microsoft Visio is not installed or registered correctly&#xA;2. The Visio process is locked or lacks permission&#xA;3. A system COM component is damaged&#xA;Details: {0}</value></data>
+  <data name="ErrorType" xml:space="preserve"><value>Error type: {0}</value></data>
+  <data name="InnerException" xml:space="preserve"><value>Inner exception: {0}</value></data>
+  <data name="DetectTypesError" xml:space="preserve"><value>Error detecting diagram types: {0}</value></data>
+  <data name="CheckingVisio" xml:space="preserve"><value>Checking the Visio environment...</value></data>
+  <data name="VisioAvailableVersion" xml:space="preserve"><value>Visio is available, version: {0}</value></data>
+  <data name="VisioVersion" xml:space="preserve"><value>Visio version: {0}</value></data>
+  <data name="VisioUnavailableDetail" xml:space="preserve"><value>Visio is unavailable: {0}</value></data>
+  <data name="VisioCheckHelp" xml:space="preserve"><value>Visio environment check failed:&#xA;1. Confirm that Microsoft Visio is installed correctly&#xA;2. Check that Visio is registered correctly&#xA;3. Try starting Visio manually&#xA;Details: {0}</value></data>
+  <data name="EnvironmentCheckException" xml:space="preserve"><value>Environment check exception: {0}</value></data>
+  <data name="EnvironmentCheckFailed" xml:space="preserve"><value>Environment check failed: {0}</value></data>
+  <data name="NoMermaidBlocks" xml:space="preserve"><value>Warning: No Mermaid code blocks were found in the file.</value></data>
+  <data name="MermaidBlockHint" xml:space="preserve"><value>Tip: Enclose diagram code in a ```mermaid ... ``` block.</value></data>
+  <data name="UnsupportedSkipped" xml:space="preserve"><value>Warning: Diagram type '{0}' is not supported and was skipped.</value></data>
+  <data name="NoDiagramsBuilt" xml:space="preserve"><value>Warning: No diagrams were built.</value></data>
+  <data name="UnsupportedFound" xml:space="preserve"><value>Found {0} unsupported diagram type(s): {1}</value></data>
+  <data name="SupportedTypes" xml:space="preserve"><value>Currently supported types: {0}</value></data>
+  <data name="DiagramsBuilt" xml:space="preserve"><value>Successfully built {0} diagram(s).</value></data>
+  <data name="InvalidOutputPath" xml:space="preserve"><value>Invalid output path: '{0}'. Specify a .vsdx file path or an existing directory.</value></data>
+  <data name="VisioStartupTimeout" xml:space="preserve"><value>Visio automation did not respond within {0} seconds. Close any Visio dialogs or orphaned Visio processes, then restart md2visio before trying again.</value></data>
+  <data name="RestartAfterTimeout" xml:space="preserve"><value>Visio automation previously timed out. Restart md2visio before trying again.</value></data>
+</root>

--- a/md2visio/Resources/Strings.resx
+++ b/md2visio/Resources/Strings.resx
@@ -57,4 +57,7 @@
   <data name="InvalidOutputPath" xml:space="preserve"><value>Invalid output path: '{0}'. Specify a .vsdx file path or an existing directory.</value></data>
   <data name="VisioStartupTimeout" xml:space="preserve"><value>Visio automation did not respond within {0} seconds. Close any Visio dialogs or orphaned Visio processes, then restart md2visio before trying again.</value></data>
   <data name="RestartAfterTimeout" xml:space="preserve"><value>Visio automation previously timed out. Restart md2visio before trying again.</value></data>
+  <data name="OutputFileNotWritable" xml:space="preserve"><value>The output file cannot be written.</value></data>
+  <data name="OutputFileInUse" xml:space="preserve"><value>The output file is open in another program. Close it and try again: {0}</value></data>
+  <data name="OutputFileAccessDenied" xml:space="preserve"><value>The output file is read-only or access was denied: {0}</value></data>
 </root>

--- a/md2visio/Resources/Strings.zh-CN.resx
+++ b/md2visio/Resources/Strings.zh-CN.resx
@@ -57,4 +57,7 @@
   <data name="InvalidOutputPath" xml:space="preserve"><value>输出路径无效: '{0}'。请指定一个 .vsdx 文件路径或现有目录。</value></data>
   <data name="VisioStartupTimeout" xml:space="preserve"><value>Visio 自动化在 {0} 秒内没有响应。请关闭所有 Visio 对话框或残留的 Visio 进程，然后重新启动 md2visio 再试。</value></data>
   <data name="RestartAfterTimeout" xml:space="preserve"><value>Visio 自动化此前已超时。请重新启动 md2visio 后再试。</value></data>
+  <data name="OutputFileNotWritable" xml:space="preserve"><value>输出文件不可写入。</value></data>
+  <data name="OutputFileInUse" xml:space="preserve"><value>输出文件正在被其他程序占用，请关闭后重试：{0}</value></data>
+  <data name="OutputFileAccessDenied" xml:space="preserve"><value>输出文件为只读或访问被拒绝：{0}</value></data>
 </root>

--- a/md2visio/Resources/Strings.zh-CN.resx
+++ b/md2visio/Resources/Strings.zh-CN.resx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms</value></resheader>
+  <data name="UnsupportedDiagram" xml:space="preserve"><value>不支持的图表类型: {0}</value></data>
+  <data name="VisioComErrorDetail" xml:space="preserve"><value>Visio COM 错误: {0}</value></data>
+  <data name="VisioComError" xml:space="preserve"><value>Visio COM 错误，请确保 Microsoft Visio 已正确安装。</value></data>
+  <data name="ConversionFailed" xml:space="preserve"><value>转换失败: {0}</value></data>
+  <data name="ConversionFailedTyped" xml:space="preserve"><value>转换失败: {0}: {1}</value></data>
+  <data name="ValidatingInput" xml:space="preserve"><value>验证输入...</value></data>
+  <data name="InputFile" xml:space="preserve"><value>输入文件: {0}</value></data>
+  <data name="OutputPath" xml:space="preserve"><value>输出路径: {0}</value></data>
+  <data name="InputMissing" xml:space="preserve"><value>输入文件不存在: {0}</value></data>
+  <data name="InputMustBeMarkdown" xml:space="preserve"><value>输入文件必须是 .md 格式</value></data>
+  <data name="CreatedOutputDirectory" xml:space="preserve"><value>创建输出目录: {0}</value></data>
+  <data name="InitializingVisio" xml:space="preserve"><value>初始化 Visio...</value></data>
+  <data name="InitializingContext" xml:space="preserve"><value>初始化转换上下文...</value></data>
+  <data name="ParsingMermaid" xml:space="preserve"><value>解析 Mermaid 内容...</value></data>
+  <data name="BuildingDiagram" xml:space="preserve"><value>构建图表结构...</value></data>
+  <data name="RenderingVisio" xml:space="preserve"><value>渲染到 Visio...</value></data>
+  <data name="RenderingVisioFormat" xml:space="preserve"><value>渲染到 Visio 格式...</value></data>
+  <data name="SavingOutput" xml:space="preserve"><value>保存输出...</value></data>
+  <data name="ConversionComplete" xml:space="preserve"><value>转换完成!</value></data>
+  <data name="GeneratedFiles" xml:space="preserve"><value>生成 {0} 个文件:</value></data>
+  <data name="UnsupportedTypesInFile" xml:space="preserve"><value>文件中包含不支持的图表类型: {0}&#xA;当前支持: {1}</value></data>
+  <data name="NoValidDiagram" xml:space="preserve"><value>文件中未找到有效的 Mermaid 图表。&#xA;请确保使用 ```mermaid ... ``` 格式包裹图表代码。</value></data>
+  <data name="NoOutputWarning" xml:space="preserve"><value>转换完成但未找到输出文件。</value></data>
+  <data name="NoOutputError" xml:space="preserve"><value>转换完成但未生成输出文件。请检查输出路径和权限设置。</value></data>
+  <data name="StartingConversion" xml:space="preserve"><value>开始转换...</value></data>
+  <data name="OutputDirectory" xml:space="preserve"><value>输出目录: {0}</value></data>
+  <data name="PreparingEnvironment" xml:space="preserve"><value>准备转换环境...</value></data>
+  <data name="ExecutingCore" xml:space="preserve"><value>开始执行核心转换逻辑...</value></data>
+  <data name="CoreComplete" xml:space="preserve"><value>核心转换逻辑执行完成</value></data>
+  <data name="UnknownError" xml:space="preserve"><value>未知错误</value></data>
+  <data name="FeatureNotImplemented" xml:space="preserve"><value>功能未实现: {0}</value></data>
+  <data name="ComException" xml:space="preserve"><value>COM异常: {0} (HRESULT: 0x{1})</value></data>
+  <data name="ComExceptionHelp" xml:space="preserve"><value>COM组件异常，可能的原因：&#xA;1. Microsoft Visio未正确安装或注册&#xA;2. Visio进程被锁定或权限不足&#xA;3. 系统COM组件损坏&#xA;详细错误: {0}</value></data>
+  <data name="ErrorType" xml:space="preserve"><value>异常类型: {0}</value></data>
+  <data name="InnerException" xml:space="preserve"><value>内部异常: {0}</value></data>
+  <data name="DetectTypesError" xml:space="preserve"><value>检测文件类型时出错: {0}</value></data>
+  <data name="CheckingVisio" xml:space="preserve"><value>正在检查Visio环境...</value></data>
+  <data name="VisioAvailableVersion" xml:space="preserve"><value>Visio可用，版本: {0}</value></data>
+  <data name="VisioVersion" xml:space="preserve"><value>Visio版本: {0}</value></data>
+  <data name="VisioUnavailableDetail" xml:space="preserve"><value>Visio不可用: {0}</value></data>
+  <data name="VisioCheckHelp" xml:space="preserve"><value>Visio环境检查失败：&#xA;1. 请确认Microsoft Visio已正确安装&#xA;2. 检查Visio是否已正确注册&#xA;3. 尝试手动启动Visio测试&#xA;错误详情: {0}</value></data>
+  <data name="EnvironmentCheckException" xml:space="preserve"><value>环境检查异常: {0}</value></data>
+  <data name="EnvironmentCheckFailed" xml:space="preserve"><value>环境检查失败: {0}</value></data>
+  <data name="NoMermaidBlocks" xml:space="preserve"><value>警告: 文件中未找到任何 mermaid 代码块</value></data>
+  <data name="MermaidBlockHint" xml:space="preserve"><value>提示: 请确保使用 ```mermaid ... ``` 格式包裹图表代码</value></data>
+  <data name="UnsupportedSkipped" xml:space="preserve"><value>警告: 图表类型 '{0}' 暂未支持，已跳过</value></data>
+  <data name="NoDiagramsBuilt" xml:space="preserve"><value>警告: 未构建任何图表</value></data>
+  <data name="UnsupportedFound" xml:space="preserve"><value>发现 {0} 个不支持的图表类型: {1}</value></data>
+  <data name="SupportedTypes" xml:space="preserve"><value>当前支持的类型: {0}</value></data>
+  <data name="DiagramsBuilt" xml:space="preserve"><value>成功构建 {0} 个图表</value></data>
+  <data name="InvalidOutputPath" xml:space="preserve"><value>输出路径无效: '{0}'。请指定一个 .vsdx 文件路径或现有目录。</value></data>
+  <data name="VisioStartupTimeout" xml:space="preserve"><value>Visio 自动化在 {0} 秒内没有响应。请关闭所有 Visio 对话框或残留的 Visio 进程，然后重新启动 md2visio 再试。</value></data>
+  <data name="RestartAfterTimeout" xml:space="preserve"><value>Visio 自动化此前已超时。请重新启动 md2visio 后再试。</value></data>
+</root>

--- a/md2visio/struc/figure/FigureBuilderFactory.cs
+++ b/md2visio/struc/figure/FigureBuilderFactory.cs
@@ -1,5 +1,6 @@
 using md2visio.mermaid.cmn;
 using md2visio.Api;
+using md2visio.Localization;
 using md2visio.vsdx.@base;
 using System.Reflection;
 
@@ -79,8 +80,8 @@ namespace md2visio.struc.figure
             // 检查是否找到任何 mermaid 块
             if (iter.Context?.StateList == null || iter.Context.StateList.Count == 0)
             {
-                _context.Log("警告: 文件中未找到任何 mermaid 代码块");
-                _context.Log("提示: 请确保使用 ```mermaid ... ``` 格式包裹图表代码");
+                _context.Log(CoreStrings.Get("NoMermaidBlocks"));
+                _context.Log(CoreStrings.Get("MermaidBlockHint"));
                 return;
             }
 
@@ -106,7 +107,7 @@ namespace md2visio.struc.figure
                         // 检查是否实现
                         if (!builderDict.ContainsKey(word))
                         {
-                            _context.Log($"警告: 图表类型 '{word}' 暂未支持，已跳过");
+                            _context.Log(CoreStrings.Format("UnsupportedSkipped", word));
                             if (!unsupportedTypes.Contains(word))
                                 unsupportedTypes.Add(word);
 
@@ -133,16 +134,16 @@ namespace md2visio.struc.figure
             // 汇总信息
             if (figuresBuilt == 0)
             {
-                _context.Log("警告: 未构建任何图表");
+                _context.Log(CoreStrings.Get("NoDiagramsBuilt"));
                 if (unsupportedTypes.Count > 0)
                 {
-                    _context.Log($"发现 {unsupportedTypes.Count} 个不支持的图表类型: {string.Join(", ", unsupportedTypes)}");
-                    _context.Log($"当前支持的类型: {GetSupportedTypesString()}");
+                    _context.Log(CoreStrings.Format("UnsupportedFound", unsupportedTypes.Count, string.Join(", ", unsupportedTypes)));
+                    _context.Log(CoreStrings.Format("SupportedTypes", GetSupportedTypesString()));
                 }
             }
             else
             {
-                _context.Log($"成功构建 {figuresBuilt} 个图表");
+                _context.Log(CoreStrings.Format("DiagramsBuilt", figuresBuilt));
             }
         }
 
@@ -286,7 +287,7 @@ namespace md2visio.struc.figure
             }
             else
             {
-                throw new ArgumentException($"输出路径无效: '{outputFile}'。请指定一个 .vsdx 文件路径或现有目录。");
+                throw new ArgumentException(CoreStrings.Format("InvalidOutputPath", outputFile));
             }
         }
     }

--- a/md2visio/struc/graph/CompoundGraphLayout.cs
+++ b/md2visio/struc/graph/CompoundGraphLayout.cs
@@ -1,0 +1,283 @@
+namespace md2visio.struc.graph;
+
+internal sealed record LayoutNode(string Id, string? ParentId, double Width, double Height, int Order);
+internal sealed record LayoutGroup(string Id, string? ParentId, string Direction, int Order);
+internal sealed record LayoutEdge(string FromId, string ToId);
+internal sealed record LayoutRect(double CenterX, double CenterY, double Width, double Height);
+
+internal sealed class CompoundGraphLayoutResult
+{
+    public Dictionary<string, LayoutRect> Nodes { get; } = new(StringComparer.Ordinal);
+    public Dictionary<string, LayoutRect> Groups { get; } = new(StringComparer.Ordinal);
+}
+
+internal static class CompoundGraphLayout
+{
+    private const string RootId = "$root";
+    private const double ItemGap = 0.65;
+    private const double RankGap = 0.9;
+    private const double GroupPadding = 0.45;
+    private const double GroupTitleHeight = 0.3;
+
+    private sealed class Box
+    {
+        public required string Id { get; init; }
+        public required bool IsGroup { get; init; }
+        public required int Order { get; init; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+        public double X { get; set; }
+        public double Y { get; set; }
+        public List<Box> Children { get; } = [];
+    }
+
+    public static CompoundGraphLayoutResult Calculate(
+        IReadOnlyCollection<LayoutNode> nodes,
+        IReadOnlyCollection<LayoutGroup> groups,
+        IReadOnlyCollection<LayoutEdge> edges,
+        string rootDirection)
+    {
+        var nodesById = nodes.ToDictionary(n => n.Id, StringComparer.Ordinal);
+        var groupsById = groups.ToDictionary(g => g.Id, StringComparer.Ordinal);
+        var childrenByParent = groups
+            .GroupBy(g => g.ParentId ?? RootId)
+            .ToDictionary(g => g.Key, g => g.OrderBy(x => x.Order).ToList(), StringComparer.Ordinal);
+
+        string ParentOfNode(string nodeId) => nodesById[nodeId].ParentId ?? RootId;
+        string ParentOfGroup(string groupId) => groupsById[groupId].ParentId ?? RootId;
+
+        string? ImmediateItem(string nodeId, string containerId)
+        {
+            var parent = ParentOfNode(nodeId);
+            if (parent == containerId)
+                return nodeId;
+
+            var currentGroup = parent;
+            while (currentGroup != RootId && ParentOfGroup(currentGroup) != containerId)
+                currentGroup = ParentOfGroup(currentGroup);
+            return currentGroup == RootId ? null : currentGroup;
+        }
+
+        Box BuildGroup(string groupId, string direction, int order)
+        {
+            var box = new Box { Id = groupId, IsGroup = groupId != RootId, Order = order };
+
+            foreach (var node in nodes.Where(n => (n.ParentId ?? RootId) == groupId).OrderBy(n => n.Order))
+            {
+                box.Children.Add(new Box
+                {
+                    Id = node.Id,
+                    IsGroup = false,
+                    Order = node.Order,
+                    Width = Math.Max(node.Width, 0.1),
+                    Height = Math.Max(node.Height, 0.1)
+                });
+            }
+
+            if (childrenByParent.TryGetValue(groupId, out var childGroups))
+            {
+                foreach (var child in childGroups)
+                    box.Children.Add(BuildGroup(child.Id, child.Direction, child.Order));
+            }
+
+            var itemIds = box.Children.Select(c => c.Id).ToHashSet(StringComparer.Ordinal);
+            var mappedEdges = new HashSet<(string From, string To)>();
+            foreach (var edge in edges)
+            {
+                var from = ImmediateItem(edge.FromId, groupId);
+                var to = ImmediateItem(edge.ToId, groupId);
+                if (from != null && to != null && from != to && itemIds.Contains(from) && itemIds.Contains(to))
+                    mappedEdges.Add((from, to));
+            }
+
+            PlaceItems(box.Children, mappedEdges, direction);
+            SizeContainer(box);
+            return box;
+        }
+
+        var root = BuildGroup(RootId, rootDirection, -1);
+        var result = new CompoundGraphLayoutResult();
+
+        void Flatten(Box box, double offsetX, double offsetY)
+        {
+            var absoluteX = offsetX + box.X;
+            var absoluteY = offsetY + box.Y;
+            if (box.Id != RootId)
+            {
+                var rect = new LayoutRect(absoluteX, absoluteY, box.Width, box.Height);
+                if (box.IsGroup) result.Groups[box.Id] = rect;
+                else result.Nodes[box.Id] = rect;
+            }
+
+            foreach (var child in box.Children)
+                Flatten(child, absoluteX, absoluteY);
+        }
+
+        Flatten(root, 0, 0);
+        return result;
+    }
+
+    private static void PlaceItems(
+        List<Box> items,
+        IReadOnlyCollection<(string From, string To)> edges,
+        string direction)
+    {
+        if (items.Count == 0) return;
+
+        var ranks = CalculateRanks(items.Select(i => i.Id), edges);
+        var rankGroups = items
+            .GroupBy(i => ranks.GetValueOrDefault(i.Id))
+            .OrderBy(g => g.Key)
+            .Select(g => g.OrderBy(i => i.Order).ToList())
+            .ToList();
+
+        var vertical = direction is "TB" or "TD" or "BT";
+        var positive = direction is "LR" or "BT";
+        var mainCursor = 0.0;
+
+        foreach (var rank in rankGroups)
+        {
+            var rankMain = rank.Max(i => vertical ? i.Height : i.Width);
+            var crossTotal = rank.Sum(i => vertical ? i.Width : i.Height) + ItemGap * (rank.Count - 1);
+            var crossCursor = -crossTotal / 2;
+            var mainCenter = (mainCursor + rankMain / 2) * (positive ? 1 : -1);
+
+            foreach (var item in rank)
+            {
+                var crossSize = vertical ? item.Width : item.Height;
+                var crossCenter = crossCursor + crossSize / 2;
+                if (vertical)
+                {
+                    item.X = crossCenter;
+                    item.Y = mainCenter;
+                }
+                else
+                {
+                    item.X = mainCenter;
+                    item.Y = crossCenter;
+                }
+                crossCursor += crossSize + ItemGap;
+            }
+
+            mainCursor += rankMain + RankGap;
+        }
+
+        // Remove any directional bias from the container's local coordinate system.
+        var left = items.Min(i => i.X - i.Width / 2);
+        var right = items.Max(i => i.X + i.Width / 2);
+        var bottom = items.Min(i => i.Y - i.Height / 2);
+        var top = items.Max(i => i.Y + i.Height / 2);
+        var centerX = (left + right) / 2;
+        var centerY = (bottom + top) / 2;
+        foreach (var item in items)
+        {
+            item.X -= centerX;
+            item.Y -= centerY;
+        }
+    }
+
+    private static void SizeContainer(Box box)
+    {
+        if (box.Children.Count == 0)
+        {
+            box.Width = box.IsGroup ? GroupPadding * 2 : 0;
+            box.Height = box.IsGroup ? GroupPadding * 2 + GroupTitleHeight : 0;
+            return;
+        }
+
+        var left = box.Children.Min(i => i.X - i.Width / 2);
+        var right = box.Children.Max(i => i.X + i.Width / 2);
+        var bottom = box.Children.Min(i => i.Y - i.Height / 2);
+        var top = box.Children.Max(i => i.Y + i.Height / 2);
+
+        if (box.IsGroup)
+        {
+            box.Width = right - left + GroupPadding * 2;
+            box.Height = top - bottom + GroupPadding * 2 + GroupTitleHeight;
+            var contentCenterY = (bottom + top) / 2 - GroupTitleHeight / 2;
+            foreach (var child in box.Children)
+                child.Y -= contentCenterY;
+        }
+        else
+        {
+            box.Width = right - left;
+            box.Height = top - bottom;
+        }
+    }
+
+    private static Dictionary<string, int> CalculateRanks(
+        IEnumerable<string> itemIds,
+        IReadOnlyCollection<(string From, string To)> edges)
+    {
+        var ids = itemIds.ToList();
+        var adjacency = ids.ToDictionary(id => id, _ => new List<string>(), StringComparer.Ordinal);
+        foreach (var (from, to) in edges)
+            if (adjacency.ContainsKey(from) && adjacency.ContainsKey(to)) adjacency[from].Add(to);
+
+        var index = 0;
+        var indices = new Dictionary<string, int>(StringComparer.Ordinal);
+        var lowLinks = new Dictionary<string, int>(StringComparer.Ordinal);
+        var stack = new Stack<string>();
+        var onStack = new HashSet<string>(StringComparer.Ordinal);
+        var components = new List<List<string>>();
+
+        void StrongConnect(string id)
+        {
+            indices[id] = index;
+            lowLinks[id] = index++;
+            stack.Push(id);
+            onStack.Add(id);
+
+            foreach (var next in adjacency[id])
+            {
+                if (!indices.ContainsKey(next))
+                {
+                    StrongConnect(next);
+                    lowLinks[id] = Math.Min(lowLinks[id], lowLinks[next]);
+                }
+                else if (onStack.Contains(next))
+                {
+                    lowLinks[id] = Math.Min(lowLinks[id], indices[next]);
+                }
+            }
+
+            if (lowLinks[id] != indices[id]) return;
+            var component = new List<string>();
+            string current;
+            do
+            {
+                current = stack.Pop();
+                onStack.Remove(current);
+                component.Add(current);
+            } while (current != id);
+            components.Add(component);
+        }
+
+        foreach (var id in ids)
+            if (!indices.ContainsKey(id)) StrongConnect(id);
+
+        var componentOf = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (var i = 0; i < components.Count; i++)
+            foreach (var id in components[i]) componentOf[id] = i;
+
+        var predecessors = Enumerable.Range(0, components.Count)
+            .ToDictionary(i => i, _ => new HashSet<int>());
+        foreach (var (from, to) in edges)
+        {
+            if (!componentOf.TryGetValue(from, out var fromComponent) ||
+                !componentOf.TryGetValue(to, out var toComponent) || fromComponent == toComponent) continue;
+            predecessors[toComponent].Add(fromComponent);
+        }
+
+        var componentRanks = new Dictionary<int, int>();
+        int Rank(int component)
+        {
+            if (componentRanks.TryGetValue(component, out var rank)) return rank;
+            rank = predecessors[component].Count == 0 ? 0 : predecessors[component].Max(Rank) + 1;
+            componentRanks[component] = rank;
+            return rank;
+        }
+
+        return ids.ToDictionary(id => id, id => Rank(componentOf[id]), StringComparer.Ordinal);
+    }
+}

--- a/md2visio/struc/graph/GSubgraph.cs
+++ b/md2visio/struc/graph/GSubgraph.cs
@@ -30,6 +30,7 @@ namespace md2visio.struc.graph
         public GSubgraph(Graph parent) 
         {
             Parent = parent;
+            Direction = parent.Direction;
         }
         public Shape? VisioShape { 
             get => borderNode.VisioShape; 

--- a/md2visio/vsdx/@base/OutputFileAccess.cs
+++ b/md2visio/vsdx/@base/OutputFileAccess.cs
@@ -1,0 +1,43 @@
+using md2visio.Localization;
+
+namespace md2visio.vsdx.@base;
+
+internal enum OutputFileStatus
+{
+    Writable,
+    InUse,
+    AccessDenied
+}
+
+internal static class OutputFileAccess
+{
+    public static OutputFileStatus Check(string outputFile)
+    {
+        if (!File.Exists(outputFile)) return OutputFileStatus.Writable;
+
+        try
+        {
+            using var stream = new FileStream(
+                outputFile,
+                FileMode.Open,
+                FileAccess.ReadWrite,
+                FileShare.None);
+            return OutputFileStatus.Writable;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return OutputFileStatus.AccessDenied;
+        }
+        catch (IOException)
+        {
+            return OutputFileStatus.InUse;
+        }
+    }
+
+    public static string GetMessage(OutputFileStatus status, string outputFile) => status switch
+    {
+        OutputFileStatus.InUse => CoreStrings.Format("OutputFileInUse", outputFile),
+        OutputFileStatus.AccessDenied => CoreStrings.Format("OutputFileAccessDenied", outputFile),
+        _ => string.Empty
+    };
+}

--- a/md2visio/vsdx/@base/VBuilder.cs
+++ b/md2visio/vsdx/@base/VBuilder.cs
@@ -1,4 +1,5 @@
 using md2visio.Api;
+using md2visio.Localization;
 using Microsoft.Win32;
 using Visio = Microsoft.Office.Interop.Visio;
 
@@ -38,7 +39,7 @@ namespace md2visio.vsdx.@base
             {
                 if (!CanWriteOutputFile(outputFile, out string? reason))
                 {
-                    _context.SetError(reason ?? "输出文件不可写入。");
+                    _context.SetError(reason ?? CoreStrings.Get("OutputFileNotWritable"));
                     visioDoc.Saved = true;
                     _session.CloseDocument(visioDoc);
                     return;
@@ -55,28 +56,11 @@ namespace md2visio.vsdx.@base
 
         bool CanWriteOutputFile(string outputFile, out string? reason)
         {
-            reason = null;
-            if (!File.Exists(outputFile)) return true;
-
-            try
-            {
-                using var stream = new FileStream(
-                    outputFile,
-                    FileMode.Open,
-                    FileAccess.ReadWrite,
-                    FileShare.None);
-                return true;
-            }
-            catch (UnauthorizedAccessException)
-            {
-                reason = $"输出文件被占用或只读，无法写入：{outputFile}";
-                return false;
-            }
-            catch (IOException)
-            {
-                reason = $"输出文件正在被其他程序占用，请关闭后重试：{outputFile}";
-                return false;
-            }
+            var status = OutputFileAccess.Check(outputFile);
+            reason = status == OutputFileStatus.Writable
+                ? null
+                : OutputFileAccess.GetMessage(status, outputFile);
+            return status == OutputFileStatus.Writable;
         }
 
         public static string? GetVisioContentDirectory()

--- a/md2visio/vsdx/@base/VShapeDrawer.cs
+++ b/md2visio/vsdx/@base/VShapeDrawer.cs
@@ -172,7 +172,7 @@ namespace md2visio.vsdx.@base
         public static double ShapeSheet(Shape shape, string propName, string unit)
         {
             string sval = shape.CellsU[propName].ResultStr[unit];
-            return Convert.ToDouble(Regex.Replace(sval, unit + "| ", ""));
+            return VisioValueParser.ParseResult(sval);
         }
 
         public static double VisioUnit2MM(Shape shape)
@@ -272,7 +272,7 @@ namespace md2visio.vsdx.@base
         public static double FontSize(Shape shape, string unit)
         {
             string sval = shape.CellsU["Char.Size"].ResultStr[unit]; // pt, mm
-            return Convert.ToDouble(Regex.Replace(sval, unit + "| ", ""));
+            return VisioValueParser.ParseResult(sval);
         }
 
         public static double FontSize(Shape shape)

--- a/md2visio/vsdx/@base/VisioValueParser.cs
+++ b/md2visio/vsdx/@base/VisioValueParser.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace md2visio.vsdx.@base;
+
+internal static partial class VisioValueParser
+{
+    public static double ParseResult(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new FormatException("Visio returned an empty numeric result.");
+
+        var match = NumericValue().Match(value);
+        if (!match.Success)
+            throw new FormatException($"Visio result '{value}' does not contain a number.");
+
+        var normalized = match.Value.Replace(',', '.');
+        return double.Parse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture);
+    }
+
+    [GeneratedRegex(@"[-+]?(?:\d+(?:[.,]\d+)?|[.,]\d+)(?:[eE][-+]?\d+)?")]
+    private static partial Regex NumericValue();
+}

--- a/md2visio/vsdx/VDrawerG.cs
+++ b/md2visio/vsdx/VDrawerG.cs
@@ -4,6 +4,7 @@ using md2visio.struc.figure;
 using md2visio.struc.graph;
 using md2visio.vsdx.@base;
 using Microsoft.Office.Interop.Visio;
+using System.Globalization;
 
 namespace md2visio.vsdx
 {
@@ -25,13 +26,97 @@ namespace md2visio.vsdx
         {
             EnsureVisible(); // 确保Visio可见
             PauseForViewing(300); // 给用户时间看到初始状态
-            
-            DrawNodes(figure);
+
+            DrawCompoundGraph();
             PauseForViewing(500); // 节点绘制完成后暂停
             
             DrawEdges(figure);
             PauseForViewing(300); // 边绘制完成后暂停
         }        
+
+        void DrawCompoundGraph()
+        {
+            var nodes = figure.NodeDict.Values
+                .OfType<GNode>()
+                .Where(node => node is not GBorderNode)
+                .Distinct()
+                .ToList();
+            var subgraphs = EnumerateSubgraphs(figure).ToList();
+
+            foreach (var node in nodes)
+            {
+                Shape shape = CreateShape(node);
+                SetFillForegnd(shape, "config.themeVariables.primaryColor");
+                SetLineColor(shape, "config.themeVariables.primaryBorderColor");
+                SetTextColor(shape, "config.themeVariables.primaryTextColor");
+                shape.CellsU["LineWeight"].FormulaU = "0.75 pt";
+                PostProcessShape(node, shape);
+            }
+
+            var layoutNodes = nodes.Select((node, order) => new LayoutNode(
+                node.ID,
+                node.Container is GSubgraph parent ? parent.ID : null,
+                Width(node.VisioShape!),
+                Height(node.VisioShape!),
+                order)).ToList();
+            var layoutGroups = subgraphs.Select((group, order) => new LayoutGroup(
+                group.ID,
+                group.Parent is GSubgraph parent ? parent.ID : null,
+                group.Direction,
+                order)).ToList();
+            var layoutEdges = nodes
+                .SelectMany(node => node.OutputEdges)
+                .Distinct()
+                .Select(edge => new LayoutEdge(edge.From.ID, edge.To.ID))
+                .ToList();
+
+            var layout = CompoundGraphLayout.Calculate(layoutNodes, layoutGroups, layoutEdges, figure.Direction);
+            foreach (var node in nodes)
+            {
+                if (node.VisioShape == null || !layout.Nodes.TryGetValue(node.ID, out var rect)) continue;
+                MoveTo(node.VisioShape, rect.CenterX, rect.CenterY);
+                drawnList.AddLast(node);
+                drawnSet.Add(node);
+            }
+
+            // Inner borders first, then parents, so every border can be sent behind its content.
+            foreach (var subgraph in subgraphs.AsEnumerable().Reverse())
+            {
+                if (layout.Groups.TryGetValue(subgraph.ID, out var rect))
+                    DrawSubgraphBorder(subgraph, rect);
+            }
+        }
+
+        static IEnumerable<GSubgraph> EnumerateSubgraphs(Graph graph)
+        {
+            foreach (var subgraph in graph.Subgraphs)
+            {
+                yield return subgraph;
+                foreach (var nested in EnumerateSubgraphs(subgraph)) yield return nested;
+            }
+        }
+
+        GNode DrawSubgraphBorder(GSubgraph subGraph, LayoutRect rect)
+        {
+            GNode node = subGraph.BorderNode;
+            Shape shape = CreateShape(node);
+            shape.CellsU["Width"].FormulaU = Invariant(rect.Width);
+            shape.CellsU["Height"].FormulaU = Invariant(rect.Height);
+            shape.CellsU["PinX"].FormulaU = Invariant(rect.CenterX);
+            shape.CellsU["PinY"].FormulaU = Invariant(rect.CenterY);
+            shape.CellsU["FillPattern"].FormulaU = "0";
+            shape.CellsU["VerticalAlign"].FormulaU = "0";
+            shape.Text = subGraph.Label;
+            SetFillForegnd(shape, "config.themeVariables.secondaryColor");
+            SetLineColor(shape, "config.themeVariables.secondaryBorderColor");
+            SetTextColor(shape, "config.themeVariables.secondaryTextColor");
+            shape.CellsU["LineWeight"].FormulaU = "0.75 pt";
+            visioApp.DoCmd((short)VisUICmds.visCmdObjectSendToBack);
+            subGraph.VisioShape = shape;
+            return node;
+        }
+
+        static string Invariant(double value) => value.ToString("0.###############", CultureInfo.InvariantCulture);
 
         void DrawNodes(Graph graph)
         {
@@ -231,9 +316,10 @@ namespace md2visio.vsdx
                     Shape shape = CreateEdge(edge);
                     if (!TryGlueEdge(edge, shape, node.VisioShape, edge.To.VisioShape))
                     {
-                        VisAutoConnectDir dir = ResolveAutoConnectDir(node.VisioShape, edge.To.VisioShape);
-                        node.VisioShape.AutoConnect(edge.To.VisioShape, dir, shape);
-                        shape.Delete();
+                        // AutoConnect is intentionally avoided here: Visio may reposition both
+                        // endpoint shapes and destroy the compound graph layout.
+                        shape.CellsU["BeginX"].GlueTo(node.VisioShape.CellsU["PinX"]);
+                        shape.CellsU["EndX"].GlueTo(edge.To.VisioShape.CellsU["PinX"]);
                     }
                     drawnEdges.Add(edge);
                     PauseForViewing(100); // 每条边绘制后暂停
@@ -450,8 +536,6 @@ namespace md2visio.vsdx
 
         bool TryGlueEdge(GEdge edge, Shape connector, Shape from, Shape to)
         {
-            if (edge.From.NodeShape.Shape != "tri" && edge.To.NodeShape.Shape != "tri") return false;
-
             VisAutoConnectDir dir = ResolveAutoConnectDir(from, to);
             int fromRow = FindBestConnectionRow(from, dir);
             int toRow = FindBestConnectionRow(to, OppositeDir(dir));


### PR DESCRIPTION
## Summary  - add English as the default UI language while preserving Simplified Chinese - add a live, persisted language selector and resource-backed GUI/core messages
- remember the last valid output folder between launches - add persistent conversion logs and a bounded Visio automation startup timeout - parse localized Visio measurement strings such as `2.8222 mm.` safely - replace per-subgraph flowchart placement with a compound ranked layout - preserve calculated positions by gluing connectors instead of using Visio `AutoConnect` - inherit the parent flow direction inside subgraphs unless Mermaid overrides it  ## Why  The WinForms GUI and conversion pipeline had user-facing Chinese strings embedded directly in code. Visio automation could block indefinitely during startup, and localized unit strings returned by Visio caused `FormatException` failures during rendering.  Flowcharts with subgraphs also rendered with detached or overlapping containers because each group was positioned independently and `AutoConnect` subsequently moved nodes while routing edges.  ## Impact  The application now starts in English by default, can switch between English and Simplified Chinese, remains responsive when Visio startup stalls, and records diagnostic logs under the user's local application data directory. Compound flowcharts are ranked globally, keep nodes inside their groups, support cycles, and retain their calculated geometry when connectors are added.  ## Validation  - `dotnet test md2visio.Tests/md2visio.Tests.csproj --configuration Release --no-restore` (30 passed) - `dotnet build md2visio.sln --configuration Release --no-restore` (0 warnings, 0 errors) - launched the Release GUI and verified the English window title - converted `flatirons-customer-operating-model.md` through Visio, exported the result to PDF, and visually verified group containment, non-overlap, inherited top-to-bottom direction, and preserved node positions 